### PR TITLE
Update tradecalc.py

### DIFF
--- a/tradecalc.py
+++ b/tradecalc.py
@@ -829,7 +829,7 @@ class TradeCalc(object):
 
         # Penalty is expressed as percentage, reduce it to a multiplier
         if tdenv.lsPenalty:
-            lsPenalty = min(tdenv.lsPenalty / 100, 1)
+            lsPenalty = max(min(tdenv.lsPenalty / 100, 1), 0)
         else:
             lsPenalty = 0
 

--- a/tradecalc.py
+++ b/tradecalc.py
@@ -829,7 +829,7 @@ class TradeCalc(object):
 
         # Penalty is expressed as percentage, reduce it to a multiplier
         if tdenv.lsPenalty:
-            lsPenalty = tdenv.lsPenalty / 100
+            lsPenalty = min(tdenv.lsPenalty / 100, 1)
         else:
             lsPenalty = 0
 


### PR DESCRIPTION
Cap distance penalty proportion at 1 to prevent weirdness if passing numbers greater than 100. Anyway, it is defined as a percentage so should be strictly in [0, 1].