### PR TITLE
Add Batch Importing for .prices files into Trade Dangerous

### DIFF
--- a/plugins/edmc_batch_plug.py
+++ b/plugins/edmc_batch_plug.py
@@ -1,0 +1,137 @@
+import os
+import re
+import tradedb
+import tradeenv
+import cache
+
+from pathlib import Path
+from commands.exceptions import *
+from plugins import PluginException, ImportPluginBase
+
+class ImportPlugin(ImportPluginBase):
+    """
+    Plugin that imports multiple .price files at once
+    """
+
+    PRICE_GLOB = "*.prices"
+    TEMP_FILE_PATH = "tmp/batch_prices.prices"
+
+    pluginOptions = {
+        'files': 'Path to some .price files to import (file=file1;file2)',
+        'folder': 'Path to a folder containing .price files (folder=pathToFolder)'
+    }
+
+    def __init__(self, tdb, tdenv):
+        super().__init__(tdb, tdenv)
+
+    """
+    Returns the newest file.
+    """
+    def file_get_newer(self, a, b):
+        if a.stat().st_mtime > b.stat().st_mtime:
+            return a
+        else:
+            return b
+
+    """
+    Returns a list of stations in a file
+    """
+    def file_get_stations(self, a):
+        contents = a.read_text()
+        stations = []
+        for line in contents.split("\n"):
+            if "@" in line:
+                stations.append(line[2:])
+        return stations
+
+    """
+    Given a list of files, does analysis to determine
+    whether they are duplicates.
+    """
+    def sanitize_files(self, files):
+        stations_seen = {}
+
+        for f in files:
+            filePath = Path(f)
+            if not filePath.is_file():
+                raise CommandLineError("File not found: {}".format(
+                    str(filePath)
+                ))
+            
+            stations = self.file_get_stations(filePath)
+
+            # Does not support resolving multiple stations (yet)
+            if len(stations) > 1:
+                raise PluginException("EDMC Batch unable to process files with multiple stations. Use normal import.")
+
+            for s in stations:
+                if(s in stations_seen):
+                    cur_file = stations_seen[s]
+                    # Set the newer file as the one we'll use.
+                    stations_seen[s] = self.file_get_newer(cur_file, f)
+                else:
+                    stations_seen[s] = f
+
+        return stations_seen.values()
+
+    """
+    Set the environment for the import command to import our files
+    """
+    def set_environment(self, files):
+        tdenv = self.tdenv
+        path_list = files
+
+        # We now have a list of paths. Add all contents to a new file
+        temp_file = open(self.TEMP_FILE_PATH, "w")
+
+        for f in path_list:
+            contents = f.read_text()
+            temp_file.writelines("# File: {}\n".format(f))
+            temp_file.write(contents)
+
+        # Set the file we're reading from to the temp file
+        tdenv.filename = self.TEMP_FILE_PATH
+
+    def split_files(self, files):
+        file_list = self.getOption("files").split(";")
+        path_list = []
+        for f in file_list:
+            path_list.append(Path(f))
+        return path_list
+
+    def get_prices_in_folder(self, directory):
+        folderToSplit = Path(directory)
+        if not folderToSplit.is_dir():
+            raise CommandLineError("Path is not a directory: {}".format(
+                str(folderToSplit)
+            ))
+
+        filesInFolder = folderToSplit.glob(self.PRICE_GLOB)
+        file_list = []
+        for i in filesInFolder:
+            file_list.append(i)
+
+        return file_list
+
+    def run(self):
+        # Grab files option and validate
+        files = self.getOption("files")
+        folder = self.getOption("folder")
+
+        if files is None and folder is None:
+            raise PluginException("Argument Required")
+
+        # The list of files to import...
+        file_list = []
+        
+        if files:
+            file_list.extend(self.split_files(files))
+        if folder:
+            file_list.extend(self.get_prices_in_folder(folder))
+
+        # Split into a path list, verify all paths are good.
+        self.set_environment(self.sanitize_files(file_list))
+        return True
+
+    def finish(self):
+        return True


### PR DESCRIPTION
Hello!

While flying around the galaxy, I use Elite Dangerous Market Connector to get Trade Dangerous prices files. I import these files so that I can get more accurate advice from Trade Dangerous without having to download from eddb, which takes about 25 minutes for me.

I end up with a lot of .prices files, so I wrote a tiny script to import them all into Trade Dangerous. However, that took way too long to import, up to 10 minutes with 15 or so files! This is because I had to import the files one by one.

The example on the wiki, where you type `trade.py import *.prices` error-ed out on Windows 10. It doesn't look like the code handles multiple files. 

So, I wrote this batch importer to speed up the process. It simply delays regenerating the prices file until all files have been processed.

The way you invoke it is: `trade.py import --batch "file1;file2;file3"`, with paths separated by a semicolon. The quotes are optional, but necessary if any path has a space.

Using this, my import time has gone down to under a minute for 25~ files.

I'd like a quick look over on this @eyeonus , since this is my first time touching your code-base, and I don't want to do something like corrupting the database. 

