### PR TITLE
On Item - item_id and fdev_id should not form a composite key

### DIFF
--- a/data/TradeDangerous.sql
+++ b/data/TradeDangerous.sql
@@ -198,13 +198,11 @@ CREATE TABLE Item
    avg_price INTEGER,
    fdev_id INTEGER,
 
-   UNIQUE (item_id, fdev_id),
-
    FOREIGN KEY (category_id) REFERENCES Category(category_id)
     ON UPDATE CASCADE
     ON DELETE CASCADE
  );
- CREATE INDEX idx_item_by_fdev_id ON Item (fdev_id);
+ CREATE UNIQUE INDEX idx_item_by_fdev_id ON Item (fdev_id);
 
 
 CREATE TABLE StationItem


### PR DESCRIPTION
Closes #35

Since PRIMARY KEY requires that the item_id is unique then a UNIQUE index for fdev_id should be enough.