### PR TITLE
Properly checking. os.environ may not have "NUMPY" as a string even w…

### DIFF
--- a/tradedb.py
+++ b/tradedb.py
@@ -69,10 +69,9 @@ import sys
 
 haveNumpy = False
 try:
-    if os.environ['NUMPY']:
-        import numpy
-        import numpy.linalg
-        haveNumpy = True
+    import numpy
+    import numpy.linalg
+    haveNumpy = True
 except (KeyError, ImportError):
     pass
 if not haveNumpy:


### PR DESCRIPTION
…hen numpy is installed. If it is not installed, it throws an import error, so the try/except block still works

Relates to issue #40