### PR TITLE
fix: avoid TypeError if TD_EDDB is not set

### DIFF
--- a/tests/test_trade_import_eddblink.py
+++ b/tests/test_trade_import_eddblink.py
@@ -1,4 +1,4 @@
-from os import path
+import os
 
 import pytest
 
@@ -10,22 +10,33 @@ PROG = "trade"
 tdb = None
 tdenv = None
 
+
 def setup_module():
     global tdb
     global tdenv
     copy_fixtures()
     tdb, tdenv = tdfactory()
 
+
 def teardown_module():
     tdb.close()
 
+
 class TestTradeImportEddblink(object):
+    def test_create_instance(self, monkeypatch):
+        plug = module.ImportPlugin(tdb, tdenv)
+        assert module.UPGRADES == "modules.json"
+        assert os.path.join('data', 'eddb') in str(plug.dataPath)
+        
+        monkeypatch.setitem(os.environ, 'TD_EDDB', '/my/testdir')
+        plug = module.ImportPlugin(tdb, tdenv)
+        assert os.path.join('my', 'testdir') in str(plug.dataPath)
 
     @pytest.mark.slow
     def test_upgrades(self, capsys):
         plug = module.ImportPlugin(tdb, tdenv)
         assert module.UPGRADES == "modules.json"
-        assert path.join('data', 'eddb') in str(plug.dataPath)
+        assert os.path.join('data', 'eddb') in str(plug.dataPath)
         plug.downloadFile(module.UPGRADES, plug.upgradesPath)
         assert (plug.dataPath / plug.upgradesPath).is_file()
 

--- a/tradedangerous/plugins/eddblink_plug.py
+++ b/tradedangerous/plugins/eddblink_plug.py
@@ -58,7 +58,7 @@ class ImportPlugin(plugins.ImportPluginBase):
     def __init__(self, tdb, tdenv):
         super().__init__(tdb, tdenv)
         
-        self.dataPath = Path(os.environ.get('TD_EDDB')) or tdb.dataPath / Path("eddb")
+        self.dataPath = Path(os.environ.get('TD_EDDB')) if os.environ.get('TD_EDDB') else tdb.dataPath / Path("eddb")
         self.commoditiesPath = Path(COMMODITIES)
         self.systemsPath = Path(SYSTEMS)
         self.stationsPath = Path(STATIONS)


### PR DESCRIPTION

Path(os.environ.get('TD_EDDB')) raises a TypeError if not set.
Test paths in both cases.