### PR TITLE
Adding some colorization for readability, defaulting to off

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -115,15 +115,15 @@ latex_elements = {
     # The paper size ('letterpaper' or 'a4paper').
     #
     # 'papersize': 'letterpaper',
-
+    
     # The font size ('10pt', '11pt' or '12pt').
     #
     # 'pointsize': '10pt',
-
+    
     # Additional stuff for the LaTeX preamble.
     #
     # 'preamble': '',
-
+    
     # Latex figure (float) alignment
     #
     # 'figure_align': 'htbp',

--- a/tradedangerous/commands/__init__.py
+++ b/tradedangerous/commands/__init__.py
@@ -221,9 +221,9 @@ class CommandIndex(object):
                     help = 'Increase level of detail in output.',
                     default = 0, required = False, action = 'count',
                 )
-        stdArgs.add_argument('--colorize', '-c',
-                    help = 'Print output with some colorization.',
-                    default = 0, required = False, action = 'count',
+        stdArgs.add_argument('--color', '-c',
+                    help = 'Add color to output for enhanced readability.',
+                    default = False, action = 'store_true',
                 )
         stdArgs.add_argument('--quiet', '-q',
                     help = 'Reduce level of detail in output.',

--- a/tradedangerous/commands/__init__.py
+++ b/tradedangerous/commands/__init__.py
@@ -42,7 +42,7 @@ class HelpAction(argparse.Action):
         argparse action helper for printing the argument usage,
         because Python 3.4's argparse is ever-so subtly very broken.
     """
-
+    
     def __call__(self, parser, namespace, values, option_string = None):
         raise exceptions.UsageError(
                 "TradeDangerous help",
@@ -85,7 +85,7 @@ def _findFromFile(cmd, prefix = '.tdrc'):
 
 
 class CommandIndex(object):
-
+    
     def usage(self, argv):
         """
             Generate the outlying usage text for TD.
@@ -134,7 +134,7 @@ class CommandIndex(object):
                 .format(prog = argv[0], cmd = lastCmdName)
             )
         return text
-
+    
     def parse(self, argv, fromfile_prefix = '+'):
         if len(argv) <= 1 or argv[1] == '--help' or argv[1] == '-h':
             raise exceptions.UsageError(
@@ -174,7 +174,7 @@ class CommandIndex(object):
             cmdModule = candidates[0][1]
         
         class ArgParser(argparse.ArgumentParser):
-
+            
             def error(self, message):
                 raise exceptions.CommandLineError(message, self.format_usage())
         

--- a/tradedangerous/commands/__init__.py
+++ b/tradedangerous/commands/__init__.py
@@ -221,6 +221,10 @@ class CommandIndex(object):
                     help = 'Increase level of detail in output.',
                     default = 0, required = False, action = 'count',
                 )
+        stdArgs.add_argument('--colorize', '-c',
+                    help = 'Print output with some colorization.',
+                    default = 0, required = False, action = 'count',
+                )
         stdArgs.add_argument('--quiet', '-q',
                     help = 'Reduce level of detail in output.',
                     default = 0, required = False, action = 'count',

--- a/tradedangerous/commands/commandenv.py
+++ b/tradedangerous/commands/commandenv.py
@@ -25,7 +25,7 @@ class CommandResults(object):
 
 
 class ResultRow(object):
-
+    
     def __init__(self, **kwargs):
         for k, v in kwargs.items():
             setattr(self, k, v)
@@ -62,7 +62,7 @@ class CommandEnv(TradeEnv):
                                 cwdPath, self.cwd)
         if self.cwd:
             os.chdir(self.cwd)
-
+    
     def run(self, tdb):
         """
             Set the current database context for this env and check that
@@ -79,10 +79,10 @@ class CommandEnv(TradeEnv):
         
         results = CommandResults(self)
         return self._cmd.run(results, self, tdb)
-
+    
     def render(self, results):
         self._cmd.render(self, results, self, self.tdb)
-
+    
     def checkMFD(self):
         self.mfd = None
         try:
@@ -93,9 +93,9 @@ class CommandEnv(TradeEnv):
         
         from ..mfd import X52ProMFD
         self.mfd = X52ProMFD()
-
+    
     def checkFromToNear(self):
-
+        
         def check(label, fieldName, wantStation):
             key = getattr(self, fieldName, None)
             if not key:
@@ -111,7 +111,7 @@ class CommandEnv(TradeEnv):
                 if isinstance(place, Station):
                     return place.system
                 return place
-
+            
             if isinstance(place, Station):
                 return place
             
@@ -135,13 +135,13 @@ class CommandEnv(TradeEnv):
             if key:
                 return self.tdb.lookupPlace(key)
             return None
-
+        
         self.startStation = check('origin station', 'origin', True)
         self.stopStation = check('destination station', 'dest', True)
         self.origPlace = lookupPlace('origin', 'starting')
         self.destPlace = lookupPlace('destination', 'ending')
         self.nearSystem = check('system', 'near', False)
-
+    
     def checkAvoids(self):
         """
             Process a list of avoidances.
@@ -191,7 +191,7 @@ class CommandEnv(TradeEnv):
                     [ item.name() for item in avoidItems ],
                     [ place.name() for place in avoidPlaces ],
         )
-
+    
     def checkVias(self):
         """ Process a list of station names and build them into a list of waypoints. """
         viaPlaceNames = getattr(self, 'via', None)

--- a/tradedangerous/commands/commandenv.py
+++ b/tradedangerous/commands/commandenv.py
@@ -18,13 +18,14 @@ class CommandResults(object):
         self.cmdenv = cmdenv
         self.summary, self.rows = {}, []
     
-    def render(self, cmdenv=None, tdb=None):
+    def render(self, cmdenv = None, tdb = None):
         cmdenv = cmdenv or self.cmdenv
         tdb = tdb or cmdenv.tdb
         cmdenv._cmd.render(self, cmdenv, tdb)
 
 
 class ResultRow(object):
+
     def __init__(self, **kwargs):
         for k, v in kwargs.items():
             setattr(self, k, v)
@@ -37,7 +38,7 @@ class CommandEnv(TradeEnv):
     """
     
     def __init__(self, properties, argv, cmdModule):
-        super().__init__(properties=properties)
+        super().__init__(properties = properties)
         self.tdb = None
         self.mfd = None
         self.argv = argv or sys.argv
@@ -45,7 +46,7 @@ class CommandEnv(TradeEnv):
         if self.detail and self.quiet:
             raise CommandLineError("'--detail' (-v) and '--quiet' (-q) are mutually exclusive.")
         
-        self._cmd   = cmdModule or __main__
+        self._cmd = cmdModule or __main__
         self.wantsTradeDB = getattr(cmdModule, 'wantsTradeDB', True)
         self.usesTradeData = getattr(cmdModule, 'usesTradeData', False)
         
@@ -61,7 +62,6 @@ class CommandEnv(TradeEnv):
                                 cwdPath, self.cwd)
         if self.cwd:
             os.chdir(self.cwd)
-
 
     def run(self, tdb):
         """
@@ -80,10 +80,8 @@ class CommandEnv(TradeEnv):
         results = CommandResults(self)
         return self._cmd.run(results, self, tdb)
 
-
     def render(self, results):
         self._cmd.render(self, results, self, self.tdb)
-
 
     def checkMFD(self):
         self.mfd = None
@@ -96,8 +94,8 @@ class CommandEnv(TradeEnv):
         from ..mfd import X52ProMFD
         self.mfd = X52ProMFD()
 
-
     def checkFromToNear(self):
+
         def check(label, fieldName, wantStation):
             key = getattr(self, fieldName, None)
             if not key:
@@ -114,7 +112,6 @@ class CommandEnv(TradeEnv):
                     return place.system
                 return place
 
-
             if isinstance(place, Station):
                 return place
             
@@ -128,7 +125,7 @@ class CommandEnv(TradeEnv):
             if len(place.stations) > 1:
                 raise AmbiguityError(
                         label, key, place.stations,
-                        key=lambda key: key.name()
+                        key = lambda key: key.name()
                 )
             
             return place.stations[0]
@@ -139,13 +136,11 @@ class CommandEnv(TradeEnv):
                 return self.tdb.lookupPlace(key)
             return None
 
-
         self.startStation = check('origin station', 'origin', True)
-        self.stopStation  = check('destination station', 'dest', True)
-        self.origPlace    = lookupPlace('origin', 'starting')
-        self.destPlace    = lookupPlace('destination', 'ending')
-        self.nearSystem   = check('system', 'near', False)
-
+        self.stopStation = check('destination station', 'dest', True)
+        self.origPlace = lookupPlace('origin', 'starting')
+        self.destPlace = lookupPlace('destination', 'ending')
+        self.nearSystem = check('system', 'near', False)
 
     def checkAvoids(self):
         """
@@ -197,7 +192,6 @@ class CommandEnv(TradeEnv):
                     [ place.name() for place in avoidPlaces ],
         )
 
-
     def checkVias(self):
         """ Process a list of station names and build them into a list of waypoints. """
         viaPlaceNames = getattr(self, 'via', None)
@@ -234,3 +228,30 @@ class CommandEnv(TradeEnv):
             if not value in 'YN?':
                 raise PlanetaryError(planetary)
         self.planetary = planetary
+    
+    def colorize(self, color, rawText):
+        """
+        Set up some coloring for readability
+        """
+        colorMap = {
+            "red": "31",
+            "green": "32",
+            "yellow": "33",
+            "blue": "34",
+            "magenta": "35",
+            "cyan": "36",
+            "lightGray": "37",
+            "darkGray": "90",
+            "lightRed": "91",
+            "lightGreen": "92",
+            "lightYellow": "93",
+            "lightBlue": "94",
+            "lightMagenta": "95",
+            "lightCyan": "96",
+            "white": "97",
+        }
+        
+        # Needed in Windows and possibly OSX for color output to work.
+        os.system('color')
+        
+        return "\033[{}m{}\033[00m" .format(colorMap.get(color, "00"), rawText)

--- a/tradedangerous/commands/run_cmd.py
+++ b/tradedangerous/commands/run_cmd.py
@@ -1119,7 +1119,8 @@ def run(results, cmdenv, tdb):
             jumps=(),
             startCr=startCr,
             gainCr=0,
-            score=0
+            score=0,
+            colorize=cmdenv.colorize
         )
         for src in cmdenv.origins
     ]

--- a/tradedangerous/commands/run_cmd.py
+++ b/tradedangerous/commands/run_cmd.py
@@ -27,6 +27,12 @@ arguments = [
             metavar='CR',
             type="credits",
         ),
+    ParseArgument('--ly-per',
+            help='Maximum light years per jump.',
+            dest='maxLyPer',
+            metavar='N.NN',
+            type=float,
+        ),
 ]
 
 switches = [
@@ -87,12 +93,6 @@ switches = [
         dest='maxJumpsPer',
         metavar='N',
         type=int,
-    ),
-    ParseArgument('--ly-per',
-        help='Maximum light years per jump.',
-        dest='maxLyPer',
-        metavar='N.NN',
-        type=float,
     ),
     ParseArgument('--empty-ly',
         help='Maximum light years ship can jump when empty.',

--- a/tradedangerous/commands/run_cmd.py
+++ b/tradedangerous/commands/run_cmd.py
@@ -269,7 +269,7 @@ class Checklist(object):
         self.tdb = tdb
         self.cmdenv = cmdenv
         self.mfd = cmdenv.mfd
-
+    
     def doStep(self, action, detail = None, extra = None):
         self.stepNo += 1
         try:
@@ -287,10 +287,10 @@ class Checklist(object):
                 " ".join(item for item in (action, detail, extra) if item)
             )
         )
-
+    
     def note(self, str, addBreak = True):
         print("(i) {} (i){}".format(str, "\n" if addBreak else ""))
-
+    
     def run(self, route, cr):
         tdb, mfd = self.tdb, self.mfd
         stations, hops, jumps = route.route, route.hops, route.jumps
@@ -1121,7 +1121,6 @@ def run(results, cmdenv, tdb):
             startCr = startCr,
             gainCr = 0,
             score = 0,
-            colorize = cmdenv.colorize
         )
         for src in cmdenv.origins
     ]

--- a/tradedangerous/commands/update_gui.py
+++ b/tradedangerous/commands/update_gui.py
@@ -46,7 +46,7 @@ updateUiHelp = (
 
 class Item(object):
     """ Describe a listed, tradeable item """
-
+    
     def __init__(self, ID, catID, name, displayNo):
         self.ID, self.catID, self.name = ID, catID, name
         self.displayNo = displayNo
@@ -56,25 +56,25 @@ class ScrollingCanvas(tk.Frame):
     """
         Tk.Canvas with scrollbar.
     """
-
+    
     def __init__(self, parent):
         super().__init__(parent)
         self.parent = parent
-
+        
         self.canvas = canvas = tk.Canvas(self, borderwidth=0)
         canvas.grid(row=0, column=0)
         canvas.grid_rowconfigure(0, weight=1)
         canvas.grid_columnconfigure(0, weight=1)
-
+        
         vsb = tk.Scrollbar(parent,
                     orient=tk.VERTICAL,
                     command=canvas.yview)
         vsb.grid(row=0, column=1)
         vsb.pack(side="right", fill=tk.BOTH, expand=False)
-
+        
         canvas.configure(yscrollcommand=vsb.set)
         canvas.configure(yscrollincrement=4)
-
+        
         self.interior = interior = tk.Frame(canvas)
         canvas.create_window(0, 0, window=interior, anchor="nw", tags="interior")
         canvas.bind("<Configure>", self.onConfigure)
@@ -84,37 +84,37 @@ class ScrollingCanvas(tk.Frame):
         interior.columnconfigure(2, weight=1)
         interior.columnconfigure(3, weight=1)
         interior.columnconfigure(4, weight=1)
-
+        
         canvas.grid(row=0, column=0)
         canvas.pack(side="left", fill=tk.BOTH, expand=True)
-
+        
         self.bind_all("<MouseWheel>", self.onMouseWheel)
         canvas.bind_all("<FocusIn>", self.scrollIntoView)
-
+        
         self.pack(side="left", fill=tk.BOTH, expand=True)
 
 
     def onConfigure(self, event):
         """ Handle resizing """
-
+        
         self.canvas.configure(scrollregion=self.interior.bbox("all"))
 
 
     def onMouseWheel(self, event):
         """ Translate mouse wheel inputs to scroll bar motions """
-
+        
         self.canvas.yview_scroll(int(-1 * (event.delta/4)), "units")
 
 
     def scrollIntoView(self, event):
         """ Scroll so that a given widget is in focus """
-
+        
         canvas = self.canvas
         widget_top = event.widget.winfo_y()
         widget_bottom = widget_top + event.widget.winfo_height()
         canvas_top = canvas.canvasy(0)
         canvas_bottom = canvas_top + canvas.winfo_height()
-
+        
         if widget_bottom >= canvas_bottom:
             delta = int(canvas_bottom - widget_bottom)
             canvas.yview_scroll(-delta, "units")
@@ -128,17 +128,17 @@ class UpdateGUI(ScrollingCanvas):
         Implements a tk canvas which displays an editor
         for TradeDangerous Price Updates
     """
-
+    
     def __init__(self, parent, tdb, tdenv):
         super().__init__(parent)
-
+        
         width = tdenv.width or 640
         height = tdenv.height or 640
         sticky = 1 if tdenv.alwaysOnTop else 0
-
+        
         self.tdb = tdb
         self.tdenv = tdenv
-
+        
         self.rowNo = 0
         self.colNo = 0
         self.items = {}
@@ -147,17 +147,17 @@ class UpdateGUI(ScrollingCanvas):
         self.itemDisplays = []
         self.results = None
         self.headings = []
-
+        
         self.createWidgets()
-
+        
         self.focusOn(0, 0)
-
+        
         parent.geometry("{}x{}{:+n}{:+n}".format(
                     width+16, height,
                     tdenv.windowX,
                     tdenv.windowY,
                 ))
-
+        
         # Allow the window to be always-on-top
         parent.wm_attributes("-topmost", sticky)
 
@@ -171,7 +171,7 @@ class UpdateGUI(ScrollingCanvas):
 
     def focusOn(self, displayNo, pos):
         """ Set focus to a widget and select the text in it """
-
+        
         row = self.itemDisplays[displayNo]
         widget = row[pos][0]
         self.selectWidget(widget)
@@ -201,7 +201,7 @@ class UpdateGUI(ScrollingCanvas):
             else:
                 row[2][0].configure(state=tk.DISABLED)
                 row[2][1].set("")
-
+        
         asking = row[1][1].get()
         if asking == "0":
             row[1][1].set("")
@@ -220,9 +220,9 @@ class UpdateGUI(ScrollingCanvas):
         minCr, avgCr, maxCr = stats
         if not avgCr:
             return True
-
+        
         cr = int(widget.val.get())
-
+        
         if cr < int(minCr / 1.01) and cr < int(avgCr * 0.7):
             widget.bell()
             ok = mbox.askokcancel(
@@ -239,7 +239,7 @@ class UpdateGUI(ScrollingCanvas):
                 self.selectWidget(widget, "")
                 return False
             widget.configure(bg = '#ff8080')
-
+        
         if cr >= (maxCr * 1.01) and int(cr * 0.7) > avgCr:
             widget.bell()
             ok = mbox.askokcancel(
@@ -256,55 +256,55 @@ class UpdateGUI(ScrollingCanvas):
                 self.selectWidget(widget, "")
                 return False
             widget.configure(bg = '#8080ff')
-
+        
         return True
 
 
     def validate(self, widget):
         """ For checking the contents of a widget. """
         item, row, pos = widget.item, widget.row, widget.pos
-
+        
         value = widget.val.get()
         re.sub(" +", "", value)
         re.sub(",", "", value)
         widget.val.set(value)
-
+        
         self.validateRow(row)
-
+        
         if pos == 0:
             if not value or value == "0":
                 widget.val.set("")
                 return True
-
+            
             if not re.match(r'^\d+$', value):
                 mbox.showerror(
                         "Invalid Paying price",
                         "Price must be an numeric value (e.g. 1234)"
                         )
                 return False
-
+            
             # is it lower than the value?
             demandStats = self.demandStats[item.ID]
             if not self.checkValueAgainstStats(widget, demandStats):
                 return False
-
+        
         if pos <= 1:
             if not value or value == "0":
                 widget.val.set("")
                 return True
-
+            
             if not re.match(r'^\d+$', value):
                 mbox.showerror(
                         "Invalid Paying price",
                         "Price must be an numeric value (e.g. 1234)"
                         )
                 return False
-
+        
         if pos == 1:
             # Don't allow crazy difference between prices
             paying = int(row[0][1].get())
             asking = int(row[1][1].get())
-
+            
             if asking < paying:
                 widget.bell()
                 mbox.showerror(
@@ -313,11 +313,11 @@ class UpdateGUI(ScrollingCanvas):
                         "they sell it for.",
                         )
                 return False
-
+            
             supplyStats = self.supplyStats[item.ID]
             if not self.checkValueAgainstStats(widget, supplyStats):
                 return False
-
+            
             # https://forums.frontier.co.uk/showthread.php?t=34986&p=1162429&viewfull=1#post1162429
             # It seems that stations usually pay within 25% of the
             # asking price as a buy-back price. If the user gives
@@ -349,9 +349,9 @@ class UpdateGUI(ScrollingCanvas):
                 if not ok:
                     self.selectWidget(widget, "")
                     return False
-
+            
             return True
-
+        
         if pos == 3:
             value = widget.val.get()
             if value == "0":
@@ -375,27 +375,27 @@ class UpdateGUI(ScrollingCanvas):
             widget.val.set("?")
             self.selectWidget(widget)
             return False
-
+        
         return True
 
 
     def onShiftTab(self, event):
         """ Process user pressing Shift+TAB """
-
+        
         widget = event.widget
         if not self.validate(widget):
             return "break"
         if widget.pos > 0 or widget.item.displayNo > 0:
             # Natural flow
             return
-
+        
         self.parent.bell()
         return "break"
 
 
     def onTab(self, event):
         """ Process user pressing TAB """
-
+        
         widget = event.widget
         if not self.validate(widget):
             return "break"
@@ -413,7 +413,7 @@ class UpdateGUI(ScrollingCanvas):
             the first cell on the next line, or if
             we are at the bottom of the list, beep.
         """
-
+        
         widget = event.widget
         if not self.validate(widget):
             return "break"
@@ -422,13 +422,13 @@ class UpdateGUI(ScrollingCanvas):
         if newDisplayNo >= len(self.itemDisplays):
             self.parent.bell()
             return "break"
-
+        
         self.focusOn(newDisplayNo, 0)
 
 
     def onUp(self, event):
         """ Handle the user pressing up, go up a row """
-
+        
         widget = event.widget
         if not self.validate(widget):
             return "break"
@@ -436,13 +436,13 @@ class UpdateGUI(ScrollingCanvas):
         if widget.item.displayNo <= 0:
             self.parent.bell()
             return "break"
-
+        
         self.focusOn(widget.item.displayNo - 1, widget.pos)
 
 
     def onDown(self, event):
         """ Handle the user pressing down, go down a row """
-
+        
         widget = event.widget
         if not self.validate(widget):
             return "break"
@@ -451,7 +451,7 @@ class UpdateGUI(ScrollingCanvas):
         if newDisplayNo >= len(self.itemDisplays):
             self.parent.bell()
             return "break"
-
+        
         self.focusOn(newDisplayNo, widget.pos)
 
 
@@ -480,10 +480,10 @@ class UpdateGUI(ScrollingCanvas):
 
     def addInput(self, item, defValue, row):
         pos = len(row)
-
+        
         inputVal = tk.StringVar()
         inputVal.set(str(defValue))
-
+        
         inputEl = tk.Entry(self.interior,
                 width=10,
                 justify=tk.RIGHT,
@@ -492,7 +492,7 @@ class UpdateGUI(ScrollingCanvas):
         inputEl.row = row
         inputEl.pos = pos
         inputEl.val = inputVal
-
+        
         inputEl.bind('<Shift-Key-Tab>', self.onShiftTab)
         inputEl.bind('<Key-Tab>', self.onTab)
         inputEl.bind('<Key-Return>', self.onReturn)
@@ -520,15 +520,15 @@ class UpdateGUI(ScrollingCanvas):
 
     def addItemRow(self, ID, catID, itemName, paying, asking, demand, supply):
         row = []
-
+        
         displayNo = len(self.itemDisplays)
         item = Item(ID, catID, itemName, displayNo)
         self.items[itemName] = item
         self.itemList.append(item)
-
+        
         demandStats = self.demandStats[item.ID]
         supplyStats = self.supplyStats[item.ID]
-
+        
         self.addLabel(item.name.upper())
         self.addInput(item, paying, row)
         self.addInput(item, asking, row)
@@ -536,25 +536,25 @@ class UpdateGUI(ScrollingCanvas):
         self.addInput(item, supply, row)
         self.addLabel(demandStats[1])
         self.addLabel(supplyStats[1])
-
+        
         self.itemDisplays.append(row)
-
+        
         self.endRow()
 
 
     def createWidgets(self):
         self.addHeadings()
-
+        
         tdb, tdenv = self.tdb, self.tdenv
         station = tdenv.startStation
         self.parent.title(station.name())
-
+        
         db = tdb.getDB()
         db.row_factory = sqlite3.Row
         cur = db.cursor()
-
+        
         self.categories = self.tdb.categoryByID
-
+        
         # Do we have entries for this station?
         cur.execute("""
             SELECT  COUNT(*)
@@ -562,7 +562,7 @@ class UpdateGUI(ScrollingCanvas):
              WHERE  station_id = ?
         """, [station.ID])
         self.newStation = False if int(cur.fetchone()[0]) else True
-
+        
         cur.execute("""
             SELECT  item.item_id,
                     IFNULL(MIN(demand_price), 0),
@@ -597,7 +597,7 @@ class UpdateGUI(ScrollingCanvas):
             ID: [ minCr, int(avgCr), maxCr ]
             for ID, minCr, avgCr, maxCr in cur
         }
-
+        
         if self.newStation and not tdenv.all:
             def splashScreen():
                 mbox.showinfo(
@@ -608,7 +608,7 @@ class UpdateGUI(ScrollingCanvas):
                         )
                 self.itemDisplays[0][0][0].focus_set()
             self.parent.after(750, splashScreen)
-
+        
         # if the user specified "--all", force listing of all items
         fetchAll = (self.newStation or tdenv.all)
         siJoin = "LEFT OUTER" if fetchAll else "INNER"
@@ -634,7 +634,7 @@ class UpdateGUI(ScrollingCanvas):
         """.format(siJoin=siJoin)
         tdenv.DEBUG1("sql: {}; bind: {}", stmt, station.ID)
         cur.execute(stmt, [station.ID])
-
+        
         def describeSupply(units, level):
             if not level:
                 return ""
@@ -643,7 +643,7 @@ class UpdateGUI(ScrollingCanvas):
             if level == -1:
                 return "{}?".format(units)
             return "{}{}".format(units, ['L', 'M', 'H'][level-1])
-
+        
         lastCat = None
         for row in cur:
             cat = row["catID"]
@@ -663,7 +663,7 @@ class UpdateGUI(ScrollingCanvas):
 
     def getResults(self):
         lastCat = None
-
+        
         txt = (
                 "# Generated by TDGUI\n"
                 "\n"
@@ -675,22 +675,22 @@ class UpdateGUI(ScrollingCanvas):
             if item.catID != lastCat:
                 lastCat = item.catID
                 txt += (" + {}\n".format(self.categories[lastCat].dbname))
-
+            
             row = self.itemDisplays[item.displayNo]
             rowvals = [ val[1].get() for val in row ]
-
+            
             itemName = item.name
             paying = int(rowvals[0] or 0)
             asking = int(rowvals[1] or 0)
             demand = rowvals[2]
             supply = rowvals[3]
-
+            
             if not paying and not asking:
                 demand, supply = "-", "-"
             else:
                 if paying and not demand:
                     demand = "?"
-
+                
                 if asking == 0:
                     supply = "-"
                 elif not supply:
@@ -698,7 +698,7 @@ class UpdateGUI(ScrollingCanvas):
                 elif re.match('^\d+$', supply):
                     if int(supply) != 0:
                         supply += '?'
-
+            
             txt += ("     {item:<30s} "
                     "{paying:>10} "
                     "{asking:>10} "

--- a/tradedangerous/gui.py
+++ b/tradedangerous/gui.py
@@ -185,9 +185,9 @@ gui.getOptionBox = getOptionBox
 
 
 def main(argv = None):
-
+    
     class IORedirector(object):
-
+        
         def __init__(self, TEXT_INFO):
             self.TEXT_INFO = TEXT_INFO
     
@@ -284,7 +284,7 @@ def main(argv = None):
                     pass
                 else:
                     kwargs['kind'] = 'numeric'
-                        
+            
             win.entry(name, argVals[name] or arg.get('default'), **kwargs)
     
     def setOpts():
@@ -331,9 +331,9 @@ def main(argv = None):
             win.button("Done", setOpts, column = 8)
             win.button("Cancel", sw.hide, row = 'p', column = 9)
             sw.show()
-        
-    def updArgs(name):
     
+    def updArgs(name):
+        
         def getWidgetType(name):
             for widgetType in [WIDGET_NAMES.Entry, WIDGET_NAMES.Button, WIDGET_NAMES.CheckBox,
                                WIDGET_NAMES.RadioButton, WIDGET_NAMES.SpinBox, WIDGET_NAMES.OptionBox]:
@@ -343,7 +343,7 @@ def main(argv = None):
                 except:
                     pass
             return None
-    
+        
         # Update the stored value of the argument that's been changed.
         if name == '--plug' and argVals[name] != win.get(getWidgetType(name), name):
             win.entry('--option', '')
@@ -400,7 +400,7 @@ def main(argv = None):
                 win.label('Optional:', sticky = 'w')
                 for key in allArgs[cmd]['opt']:
                     makeWidget(key, allArgs[cmd]['opt'][key])
-        
+    
     def changeCWD():
         """
         Opens a folder select dialog.
@@ -602,11 +602,11 @@ def main(argv = None):
             for arg in index.arguments:
                 # print(arg.args[0])
                 argVals[arg.args[0]] = arg.kwargs.get('default') or None
-
+                
                 allArgs[cmd]['req'][arg.args[0]] = {kwarg : arg.kwargs[kwarg] for kwarg in arg.kwargs}
                 allArgs[cmd]['req'][arg.args[0]]['widget'] = chooseType(arg)
         # print(allArgs[cmd]['req'])
-
+        
         if index.switches:
             for arg in index.switches:
                 try:
@@ -667,7 +667,7 @@ def main(argv = None):
                     win.widgetManager.get(WIDGET_NAMES.Message, 'outputText').config(width = 560)
         
         makeWidget('--link-ly', allArgs['--link-ly'], sticky = 'w', width = 4, row = 3, column = 2)
-
+        
         makeWidget('--quiet', allArgs['--quiet'], sticky = 'e', disabled = ':', width = 1, row = 3, column = 46)
         
         makeWidget('--detail', allArgs['--detail'], sticky = 'e', disabled = ':', width = 1, row = 3, column = 47)
@@ -686,7 +686,7 @@ def main(argv = None):
         with win.scrollPane('DB', disabled = 'vertical', row = 5, column = 1, colspan = 49) as pane:
             pane.configure(width = 500, height = 20)
             win.label('db', argVals['--db'], sticky = 'w')
-        
+    
     # End of window
 
 

--- a/tradedangerous/gui.py
+++ b/tradedangerous/gui.py
@@ -432,7 +432,7 @@ def main(argv = None):
             vals = []
             # See string weirdness, above.
             if not not curArg and curArg != argBase[arg].get('default'):
-                if arg in ['--detail', '--debug', '--quiet'] or argBase == allArgs[cmd]['req']:
+                if arg in ['--detail', '--debug', '--quiet'] or (argBase == allArgs[cmd]['req'] and not arg.startswith('--')):
                     pass
                 else:
                     vals.append(str(arg))

--- a/tradedangerous/plugins/eddblink_plug.py
+++ b/tradedangerous/plugins/eddblink_plug.py
@@ -175,7 +175,7 @@ class ImportPlugin(plugins.ImportPluginBase):
                     tdenv.NOTE("Using Default Ship Index.")
                     copyfile(self.tdenv.templateDir / Path("DefaultShipIndex.json"), self.dataPath / path)
                     return True
-
+                
                 if urlTail != LIVE_LISTINGS:
                     self.options["fallback"] = True
         
@@ -183,7 +183,7 @@ class ImportPlugin(plugins.ImportPluginBase):
             # EDDB.io doesn't have live listings or the ship index.
             if urlTail == LIVE_LISTINGS:
                 return False
-
+            
             url = FALLBACK_URL + urlTail
             try:
                 response = openURL(url)

--- a/tradedangerous/tradecalc.py
+++ b/tradedangerous/tradecalc.py
@@ -210,37 +210,26 @@ class Route(object):
         """
         Set up some coloring for readability
         """
+        colorMap = {
+            "red": "\033[31m",
+            "green": "\033[32m",
+            "yellow": "\033[33m",
+            "blue": "\033[34m",
+            "magenta": "\033[35m",
+            "cyan": "\033[36m",
+            "lightGray": "\033[37m",
+            "darkGray": "\033[90m",
+            "lightRed": "\033[91m",
+            "lightGreen": "\033[92m",
+            "lightYellow": "\033[93m",
+            "lightBlue": "\033[94m",
+            "lightMagenta": "\033[95m",
+            "lightCyan": "\033[96m",
+            "white": "\033[97m",
+        }
+
         if self.colorize:
-            if color == "red":
-                return "\033[31m{}\033[00m" .format(rawText)
-            if color == "green":
-                return "\033[32m{}\033[00m" .format(rawText)
-            if color == "yellow":
-                return "\033[33m{}\033[00m" .format(rawText)
-            if color == "blue":
-                return "\033[34m{}\033[00m" .format(rawText)
-            if color == "magenta":
-                return "\033[35m{}\033[00m" .format(rawText)
-            if color == "cyan":
-                return "\033[36m{}\033[00m" .format(rawText)
-            if color == "lightGray":
-                return "\033[37m{}\033[00m" .format(rawText)
-            if color == "darkGray":
-                return "\033[90m{}\033[00m" .format(rawText)
-            if color == "lightRed":
-                return "\033[91m{}\033[00m" .format(rawText)
-            if color == "lightGreen":
-                return "\033[92m{}\033[00m" .format(rawText)
-            if color == "lightYellow":
-                return "\033[93m{}\033[00m" .format(rawText)
-            if color == "lightBlue":
-                return "\033[94m{}\033[00m" .format(rawText)
-            if color == "lightMagenta":
-                return "\033[95m{}\033[00m" .format(rawText)
-            if color == "lightCyan":
-                return "\033[96m{}\033[00m" .format(rawText)
-            if color == "white":
-                return "\033[97m{}\033[00m" .format(rawText)
+            return "{}{}\033[00m" .format(colorMap.get(color, "\033[00m"), rawText)
         else:
             return rawText
 

--- a/tradedangerous/tradecalc.py
+++ b/tradedangerous/tradecalc.py
@@ -59,6 +59,7 @@ locale.setlocale(locale.LC_ALL, '')
 
 
 class BadTimestampError(TradeException):
+
     def __init__(
             self,
             tdb,
@@ -80,11 +81,13 @@ class BadTimestampError(TradeException):
             )
         )
 
+
 class NoHopsError(TradeException):
     pass
 
 ######################################################################
 # Stuff that passes for classes (but isn't)
+
 
 class TradeLoad(namedtuple('TradeLoad', (
         'items', 'gainCr', 'costCr', 'units'
@@ -103,6 +106,7 @@ class TradeLoad(namedtuple('TradeLoad', (
         units
             Total of all the qty values in the items list.
     """
+
     def __bool__(self):
         return self.units > 0
     
@@ -121,10 +125,12 @@ class TradeLoad(namedtuple('TradeLoad', (
     def gpt(self):
         return self.gainCr / self.units if self.units else 0
 
+
 emptyLoad = TradeLoad((), 0, 0, 0)
 
 ######################################################################
 # Classes
+
 
 class Route(object):
     """
@@ -204,32 +210,6 @@ class Route(object):
     def __eq__(self, rhs):
         return self.score == rhs.score and len(self.jumps) == len(rhs.jumps)
     
-    def __colorize(self, color, rawText):
-        """
-        Set up some coloring for readability
-        """
-        colorMap = {
-            "red": "31",
-            "green": "32",
-            "yellow": "33",
-            "blue": "34",
-            "magenta": "35",
-            "cyan": "36",
-            "lightGray": "37",
-            "darkGray": "90",
-            "lightRed": "91",
-            "lightGreen": "92",
-            "lightYellow": "93",
-            "lightBlue": "94",
-            "lightMagenta": "95",
-            "lightCyan": "96",
-            "white": "97",
-        }
-        
-        os.system('color')
-        
-        return "\033[{}m{}\033[00m" .format(colorMap.get(color, "00"), rawText)
-    
     def str(self, colorize):
         return "%s -> %s" % (colorize("cyan", self.firstStation.name()), colorize("blue", self.lastStation.name()))
     
@@ -240,7 +220,7 @@ class Route(object):
         
         detail, goalSystem = tdenv.detail, tdenv.goalSystem
         
-        colorize = self.__colorize if tdenv.color else lambda x, y : y
+        colorize = tdenv.colorize if tdenv.color else lambda x, y : y
         
         credits = self.startCr + (tdenv.insurance or 0)
         gainCr = 0
@@ -254,6 +234,7 @@ class Route(object):
             for hop in hops:
                 for (tr, qty) in hop[0]:
                     yield len(tr.name(detail))
+
         longestNameLen = max(genSubValues())
         
         text = self.str(colorize)
@@ -362,6 +343,7 @@ class Route(object):
             return travelled, text
         
         if detail > 1:
+
             def decorateStation(station):
                 details = []
                 if station.lsFromStar:
@@ -383,17 +365,22 @@ class Route(object):
                     ", ".join(details or ["no details"])
                 )
                 return details
+
         else:
+
             def decorateStation(station):
                 return station.name()
         
         if detail and goalSystem:
+
             def goalDistance(station):
                 return " [Distance to {}: {:.2f} ly]\n".format(
                     goalSystem.name(),
                     station.system.distanceTo(goalSystem),
                 )
+
         else:
+
             def goalDistance(station):
                 return ""
         
@@ -502,6 +489,7 @@ class Route(object):
                 final = credits + ttlGainCr
             )
         )
+
 
 class TradeCalc(object):
     """
@@ -615,6 +603,7 @@ class TradeCalc(object):
         This is provided to make it easy to validate the results of future
         variants or optimizations of the fit algorithm.
         """
+
         def _fitCombos(offset, cr, cap, level = 1):
             if cr <= 0 or cap <= 0:
                 return emptyLoad
@@ -910,6 +899,7 @@ class TradeCalc(object):
                     if stn not in avoidPlaces and \
                         stn.system not in avoidPlaces
                 )
+
             def station_iterator(srcStation):
                 srcSys = srcStation.system
                 srcDist = srcSys.distanceTo
@@ -920,8 +910,10 @@ class TradeCalc(object):
                         (srcSys, stnSys),
                         srcDist(stnSys)
                     )
+
         else:
             getDestinations = tdb.getDestinations
+
             def station_iterator(srcStation):
                 yield from getDestinations(
                     srcStation,
@@ -997,6 +989,7 @@ class TradeCalc(object):
                 )
             
             if tdenv.debug >= 1:
+
                 def annotate(dest):
                     tdenv.DEBUG1(
                         "destSys {}, destStn {}, jumps {}, distLy {}",
@@ -1006,6 +999,7 @@ class TradeCalc(object):
                         dest.distLy
                     )
                     return True
+
                 stations = (d for d in stations if annotate(d))
             
             for dest in stations:

--- a/tradedangerous/tradecalc.py
+++ b/tradedangerous/tradecalc.py
@@ -59,7 +59,7 @@ locale.setlocale(locale.LC_ALL, '')
 
 
 class BadTimestampError(TradeException):
-
+    
     def __init__(
             self,
             tdb,
@@ -106,7 +106,7 @@ class TradeLoad(namedtuple('TradeLoad', (
         units
             Total of all the qty values in the items list.
     """
-
+    
     def __bool__(self):
         return self.units > 0
     
@@ -234,7 +234,7 @@ class Route(object):
             for hop in hops:
                 for (tr, qty) in hop[0]:
                     yield len(tr.name(detail))
-
+        
         longestNameLen = max(genSubValues())
         
         text = self.str(colorize)
@@ -343,7 +343,7 @@ class Route(object):
             return travelled, text
         
         if detail > 1:
-
+            
             def decorateStation(station):
                 details = []
                 if station.lsFromStar:
@@ -365,22 +365,22 @@ class Route(object):
                     ", ".join(details or ["no details"])
                 )
                 return details
-
+        
         else:
-
+            
             def decorateStation(station):
                 return station.name()
         
         if detail and goalSystem:
-
+            
             def goalDistance(station):
                 return " [Distance to {}: {:.2f} ly]\n".format(
                     goalSystem.name(),
                     station.system.distanceTo(goalSystem),
                 )
-
+        
         else:
-
+            
             def goalDistance(station):
                 return ""
         
@@ -603,7 +603,7 @@ class TradeCalc(object):
         This is provided to make it easy to validate the results of future
         variants or optimizations of the fit algorithm.
         """
-
+        
         def _fitCombos(offset, cr, cap, level = 1):
             if cr <= 0 or cap <= 0:
                 return emptyLoad
@@ -899,7 +899,7 @@ class TradeCalc(object):
                     if stn not in avoidPlaces and \
                         stn.system not in avoidPlaces
                 )
-
+            
             def station_iterator(srcStation):
                 srcSys = srcStation.system
                 srcDist = srcSys.distanceTo
@@ -910,10 +910,10 @@ class TradeCalc(object):
                         (srcSys, stnSys),
                         srcDist(stnSys)
                     )
-
+        
         else:
             getDestinations = tdb.getDestinations
-
+            
             def station_iterator(srcStation):
                 yield from getDestinations(
                     srcStation,
@@ -989,7 +989,7 @@ class TradeCalc(object):
                 )
             
             if tdenv.debug >= 1:
-
+                
                 def annotate(dest):
                     tdenv.DEBUG1(
                         "destSys {}, destStn {}, jumps {}, distLy {}",
@@ -999,7 +999,7 @@ class TradeCalc(object):
                         dest.distLy
                     )
                     return True
-
+                
                 stations = (d for d in stations if annotate(d))
             
             for dest in stations:

--- a/tradedangerous/tradeenv.py
+++ b/tradedangerous/tradeenv.py
@@ -39,7 +39,7 @@ class TradeEnv(object):
     
     encoding = sys.stdout.encoding
     if str(sys.stdout.encoding).upper() != 'UTF-8':
-
+        
         def uprint(self, *args, **kwargs):
             try:
                 print(*args, **kwargs)
@@ -60,7 +60,7 @@ class TradeEnv(object):
                     for arg in args
                 ]
                 print(*strs, **kwargs)
-
+    
     else:
         uprint = print
     
@@ -75,7 +75,7 @@ class TradeEnv(object):
     def __getattr__(self, key):
         """ Return the default for attributes we don't have """
         if key.startswith("DEBUG"):
-
+            
             # Self-assembling DEBUGN functions
             def __DEBUG_ENABLED(outText, *args, **kwargs):
                 print('#', outText.format(*args, **kwargs))
@@ -94,7 +94,7 @@ class TradeEnv(object):
             return debugFn
         
         if key == "NOTE":
-
+            
             def __NOTE_ENABLED(outText, *args, file = None, **kwargs):
                 self.uprint(
                     "NOTE:", str(outText).format(*args, **kwargs),
@@ -113,7 +113,7 @@ class TradeEnv(object):
             return noteFn
         
         if key == "WARN":
-
+            
             def _WARN_ENABLED(outText, *args, file = None, **kwargs):
                 self.uprint(
                     "WARNING:", str(outText).format(*args, **kwargs),

--- a/tradedangerous/tradeenv.py
+++ b/tradedangerous/tradeenv.py
@@ -28,8 +28,8 @@ class TradeEnv(object):
     defaults = {
         'debug': 0,
         'detail': 0,
-        'colorize': 0,
         'quiet': 0,
+        'color': False,
         'dataDir': os.environ.get('TD_DATA') or os.path.join(os.getcwd(), 'data'),
         'tmpDir': os.environ.get('TD_TMP') or os.path.join(os.getcwd(), 'tmp'),
         'templateDir': os.path.join(_ROOT, 'templates'),
@@ -53,7 +53,7 @@ class TradeEnv(object):
                         print(str(e))
                 strs = [
                     str(arg).
-                        encode(TradeEnv.encoding, errors='replace').
+                        encode(TradeEnv.encoding, errors = 'replace').
                         decode(TradeEnv.encoding)
                     for arg in args
                 ]
@@ -61,7 +61,7 @@ class TradeEnv(object):
     else:
         uprint = print
     
-    def __init__(self, properties=None, **kwargs):
+    def __init__(self, properties = None, **kwargs):
         properties = properties or dict()
         self.__dict__.update(self.defaults)
         if properties:
@@ -90,10 +90,10 @@ class TradeEnv(object):
             return debugFn
         
         if key == "NOTE":
-            def __NOTE_ENABLED(outText, *args, file=None, **kwargs):
+            def __NOTE_ENABLED(outText, *args, file = None, **kwargs):
                 self.uprint(
                     "NOTE:", str(outText).format(*args, **kwargs),
-                    file=file,
+                    file = file,
                 )
             
             def __NOTE_DISABLED(*args, **kwargs):
@@ -108,10 +108,10 @@ class TradeEnv(object):
             return noteFn
         
         if key == "WARN":
-            def _WARN_ENABLED(outText, *args, file=None, **kwargs):
+            def _WARN_ENABLED(outText, *args, file = None, **kwargs):
                 self.uprint(
                     "WARNING:", str(outText).format(*args, **kwargs),
-                    file=file
+                    file = file
                 )
             
             def _WARN_DISABLED(*args, **kwargs):

--- a/tradedangerous/tradeenv.py
+++ b/tradedangerous/tradeenv.py
@@ -5,6 +5,7 @@ import traceback
 import sys
 _ROOT = os.path.abspath(os.path.dirname(__file__))
 
+
 class TradeEnv(object):
     """
         Container for a TradeDangerous "environment", which is a
@@ -38,6 +39,7 @@ class TradeEnv(object):
     
     encoding = sys.stdout.encoding
     if str(sys.stdout.encoding).upper() != 'UTF-8':
+
         def uprint(self, *args, **kwargs):
             try:
                 print(*args, **kwargs)
@@ -58,6 +60,7 @@ class TradeEnv(object):
                     for arg in args
                 ]
                 print(*strs, **kwargs)
+
     else:
         uprint = print
     
@@ -72,6 +75,7 @@ class TradeEnv(object):
     def __getattr__(self, key):
         """ Return the default for attributes we don't have """
         if key.startswith("DEBUG"):
+
             # Self-assembling DEBUGN functions
             def __DEBUG_ENABLED(outText, *args, **kwargs):
                 print('#', outText.format(*args, **kwargs))
@@ -90,6 +94,7 @@ class TradeEnv(object):
             return debugFn
         
         if key == "NOTE":
+
             def __NOTE_ENABLED(outText, *args, file = None, **kwargs):
                 self.uprint(
                     "NOTE:", str(outText).format(*args, **kwargs),
@@ -108,6 +113,7 @@ class TradeEnv(object):
             return noteFn
         
         if key == "WARN":
+
             def _WARN_ENABLED(outText, *args, file = None, **kwargs):
                 self.uprint(
                     "WARNING:", str(outText).format(*args, **kwargs),

--- a/tradedangerous/tradeenv.py
+++ b/tradedangerous/tradeenv.py
@@ -28,6 +28,7 @@ class TradeEnv(object):
     defaults = {
         'debug': 0,
         'detail': 0,
+        'colorize': 0,
         'quiet': 0,
         'dataDir': os.environ.get('TD_DATA') or os.path.join(os.getcwd(), 'data'),
         'tmpDir': os.environ.get('TD_TMP') or os.path.join(os.getcwd(), 'tmp'),


### PR DESCRIPTION
This adds colorized output to trade run results. By default no change (always backward compatible), but can be enabled with --colorize/-c option.
I added definitions for many colors that aren't actually used, mostly in case colors want to change or to colorize other parts of the output.