### PR TITLE
Fix bugs in edmc_batch_plug's set_environment

### DIFF
--- a/tradedangerous/plugins/edmc_batch_plug.py
+++ b/tradedangerous/plugins/edmc_batch_plug.py
@@ -79,7 +79,7 @@ class ImportPlugin(ImportPluginBase):
         tdenv = self.tdenv
         path_list = files
         fs.ensurefolder(tdenv.tmpDir)
-        batchfile = tdenv.tmpDir / pathlib.Path(self.BATCH_FILE)
+        batchfile = tdenv.tmpDir / Path(self.BATCH_FILE)
         if batchfile.exists():
                 batchfile.unlink()
         # We now have a list of paths. Add all contents to a new file
@@ -91,7 +91,7 @@ class ImportPlugin(ImportPluginBase):
             temp_file.write(contents)
         
         # Set the file we're reading from to the temp file
-        tdenv.filename = batchfile
+        tdenv.filename = str(batchfile.absolute())
     
     def split_files(self, files):
         file_list = self.getOption("files").split(";")


### PR DESCRIPTION
This fixed two bugs in the EDMC Batch set_environment method.
The method used `pathlib.Path` while `pathlib` was not imported as a
module which threw a NameError. Secondly, the method set the
environments filename to a Path object when it should be a string.


## Tests:

### Before:
```
$ trade import -P edmc_batch --merge-import -O folder=$PWD
Traceback (most recent call last):
  File "/home/user/.local/bin/trade", line 8, in <module>
    sys.exit(main())
  File "/home/user/.local/lib/python3.8/site-packages/tradedangerous/trade.py", line 43, in main
    cli.main(sys.argv)
  File "/home/user/.local/lib/python3.8/site-packages/tradedangerous/cli.py", line 70, in main
    trade(argv)
  File "/home/user/.local/lib/python3.8/site-packages/tradedangerous/cli.py", line 125, in trade
    results = cmdenv.run(tdb)
  File "/home/user/.local/lib/python3.8/site-packages/tradedangerous/commands/commandenv.py", line 82, in run
    return self._cmd.run(results, self, tdb)
  File "/home/user/.local/lib/python3.8/site-packages/tradedangerous/commands/import_cmd.py", line 126, in run
    if not plugin.run():
  File "/home/user/.local/lib/python3.8/site-packages/tradedangerous/plugins/edmc_batch_plug.py", line 134, in run
    self.set_environment(self.sanitize_files(file_list))
  File "/home/user/.local/lib/python3.8/site-packages/tradedangerous/plugins/edmc_batch_plug.py", line 82, in set_environment
    batchfile = tdenv.tmpDir / pathlib.Path(self.BATCH_FILE)
NameError: name 'pathlib' is not defined
```

### After:
```
$ trade import -P edmc_batch --merge-import -O folder=$PWD
NOTE: Rebuilding cache file: this may take a few moments.
NOTE: Import complete: 43 new items over 1 stations in 1 systems
WARNING: Plugin did not implement finish()
NOTE: Import complete: 0 items over 1 stations in 1 systems
$ 
```