### PR TITLE
Fix exceptions/errors in EDMC batch plugin.

### DIFF
--- a/tradedangerous/plugins/edmc_batch_plug.py
+++ b/tradedangerous/plugins/edmc_batch_plug.py
@@ -79,7 +79,7 @@ class ImportPlugin(ImportPluginBase):
         tdenv = self.tdenv
         path_list = files
         fs.ensurefolder(tdenv.tmpDir)
-        batchfile = tdenv.tmpDir / pathlib.Path(self.BATCH_FILE)
+        batchfile = tdenv.tmpDir / Path(self.BATCH_FILE)
         if batchfile.exists():
                 batchfile.unlink()
         # We now have a list of paths. Add all contents to a new file
@@ -91,7 +91,7 @@ class ImportPlugin(ImportPluginBase):
             temp_file.write(contents)
         
         # Set the file we're reading from to the temp file
-        tdenv.filename = batchfile
+        tdenv.filename = batchfile.as_posix()
     
     def split_files(self, files):
         file_list = self.getOption("files").split(";")


### PR DESCRIPTION
This fixes an issue referencing pathlib, which wasn't imported as a separate name, and with the filename that's passed to the import command (it was passing a pathlib filename object rather than a string).