### PR TITLE
Avoid excessive loops

### DIFF
--- a/tradedangerous/tradecalc.py
+++ b/tradedangerous/tradecalc.py
@@ -970,31 +970,14 @@ class TradeCalc(object):
             elif loopInt:
                 uniquePath = route.route[-loopInt:-1]
             
-            stations = (
-                dest for dest in station_iterator(srcStation)
-                if dest.station != srcStation
+            stations = (d for d in station_iterator(srcStation)
+              if (d.station != srcStation) and
+                (d.station.blackMarket == 'Y' if reqBlackMarket else True) and
+                (d.station not in uniquePath if uniquePath else True) and
+                (d.station in restrictStations if restrictStations else True) and
+                (d.station.dataAge and d.station.dataAge <= maxAge if maxAge else True) and
+                (((d.system is not srcSystem) if bool(tdenv.unique) else (d.system is goalSystem or d.distLy < srcGoalDist)) if goalSystem else True)
             )
-            if reqBlackMarket:
-                stations = (d for d in stations if d.station.blackMarket == 'Y')
-            if uniquePath:
-                stations = (d for d in stations if d.station not in uniquePath)
-            if restrictStations:
-                stations = (
-                    d for d in stations
-                    if d.station in restrictStations
-                )
-            if maxAge:
-                stations = (d for d in stations if d.station.dataAge)
-                stations = (d for d in stations if d.station.dataAge <= maxAge)
-            if goalSystem:
-                if bool(tdenv.unique):
-                    stations = (
-                        d for d in stations if d.system is not srcSystem
-                    )
-                stations = (
-                    d for d in stations
-                    if d.system is goalSystem or d.distLy < srcGoalDist
-                )
             
             if tdenv.debug >= 1:
                 

--- a/tradedangerous/tradedb.py
+++ b/tradedangerous/tradedb.py
@@ -1807,42 +1807,16 @@ class TradeDB(object):
                     for station in node.system.stations:
                         yield node, station
         
-        path_iter = iter(path_iter_fn())
-        if noPlanet:
-            path_iter = iter(
-                (node, station) for (node, station) in path_iter
-                if station.planetary == 'N'
-            )
-        if avoidPlaces:
-            path_iter = iter(
-                (node, station) for (node, station) in path_iter
-                if station not in avoidPlaces
-            )
-        if maxPadSize:
-            path_iter = iter(
-                (node, station) for (node, station) in path_iter
-                if station.checkPadSize(maxPadSize)
-            )
-        if planetary:
-            path_iter = iter(
-                (node, station) for (node, station) in path_iter
-                if station.checkPlanetary(planetary)
-            )
-        if fleet:
-            path_iter = iter(
-                (node, station) for (node, station) in path_iter
-                if station.checkFleet(fleet)
-            )
-        if odyssey:
-            path_iter = iter(
-                (node, station) for (node, station) in path_iter
-                if station.checkOdyssey(odyssey)
-            )
-        if maxLsFromStar:
-            path_iter = iter(
-                (node, stn) for (node, stn) in path_iter
-                if stn.lsFromStar > 0 and stn.lsFromStar <= maxLsFromStar
-            )
+        path_iter = iter(
+          (node, station) for (node, station) in path_iter_fn()
+          if (station.planetary == 'N' if noPlanet else True) and
+            (station not in avoidPlaces if avoidPlaces else True) and
+            (station.checkPadSize(maxPadSize) if maxPadSize else True) and
+            (station.checkPlanetary(planetary) if planetary else True) and
+            (station.checkFleet(fleet) if fleet else True) and
+            (station.checkOdyssey(odyssey) if odyssey else True) and
+            (station.lsFromStar > 0 and station.lsFromStar <= maxLsFromStar if maxLsFromStar else True)
+        )
         for node, stn in path_iter:
             yield Destination(node.system, stn, node.via, node.distLy)
     


### PR DESCRIPTION
Evaluate all filter conditions instead of looping over all stations separately for condition provided.
This leads to a quite substantial speedup if multiple filter conditions are provided.

e.g. measuring `trade run --from "Xi Ursae Majoris/Durrance Dock" --credits 17m --capacity 88 --ly-per 17 --jumps 1 --hops 5 --ls-penalty 1.5 --margin 0.02 --pad-size ML --planetary N --fleet-carrier N --unique --max-days 7 --color --progress` gave me the following number:

|        |                                             |
|--------|---------------------------------------------|
| before | `15811707 function calls in 38.499 seconds` |
| after  | `14117624 function calls in 28.854 seconds` |
