### PR TITLE
qol: enable rich text

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -8,3 +8,4 @@ importlib-metadata>=1
 wheel
 coverage
 pysimdjson~=6.0.2
+rich==13.7.1

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,9 @@
 [tox]
-envlist = py37,py38,py39,py310,py311
+envlist = flake8,py37,py38,py39,py310,py311
 
 [testenv]
 deps =
-    pytest
-    coverage
+	-r requirements/dev.txt
 commands=
     coverage run --source=tradedangerous -m pytest {posargs}
     coverage report --show-missing

--- a/tradedangerous/cache.py
+++ b/tradedangerous/cache.py
@@ -919,7 +919,7 @@ def buildCache(tdb, tdenv):
     
     tdenv.NOTE(
         "Rebuilding cache file: this may take a few moments.",
-        file = sys.stderr
+        stderr=True,
     )
     
     dbPath = tdb.dbPath
@@ -963,7 +963,7 @@ def buildCache(tdb, tdenv):
         tdenv.NOTE(
                 "Missing \"{}\" file - no price data.",
                     pricesPath,
-                    file = sys.stderr,
+                    stderr=True,
         )
     
     tempDB.commit()

--- a/tradedangerous/tradeenv.py
+++ b/tradedangerous/tradeenv.py
@@ -1,18 +1,44 @@
-from __future__ import absolute_import, with_statement, print_function, division, unicode_literals
+# The runtime environment TD tools are expected to run with is encapsulated
+# into a single object, the TradeEnv. See TradeEnv docstring for more.
+from __future__ import annotations
 
 import os
-import traceback
 import sys
+import traceback
+import typing
+from contextlib import contextmanager
+
+# Import some utilities from the 'rich' library that provide ways to colorize and animate
+# the console output, along with other useful features.
+# If the user has 'EXCEPTIONS' defined to something in the environment, then we can
+# immediately benefit from beautified stacktraces.
+from rich.console import Console
+from rich.traceback import install as install_rich_traces
+
+
+if typing.TYPE_CHECKING:
+    from typing import Any, Dict, Iterator
+
+
 _ROOT = os.path.abspath(os.path.dirname(__file__))
 
 
-class TradeEnv(object):
+# Create a single instance of the console for everyone to use, unless they really
+# want to do something unusual.
+CONSOLE = Console()
+STDERR  = Console(stderr=True)
+
+if os.getenv("EXCEPTIONS"):
+    # This makes call stacks show additional context and do syntax highlighting
+    # that can turn reading a callstack from hours into seconds.
+    install_rich_traces(console=STDERR, show_locals=False, extra_lines=1)
+
+
+class TradeEnv:
     """
-        Container for a TradeDangerous "environment", which is a
-        collection of operational parameters.
+        Container for a TradeDangerous "environment", which is a collection of operational parameters.
         
-        To print debug lines, use DEBUG<N>, e.g. DEBUG0, which
-        takes a format() string and parameters, e.g.
+        To print debug lines, use DEBUG<N>, e.g. DEBUG0, which takes a format() string and parameters, e.g.
             
             DEBUG1("hello, {world}{}", "!", world="world")
         
@@ -35,51 +61,90 @@ class TradeEnv(object):
         'csvDir': os.environ.get('TD_CSV') or os.environ.get('TD_DATA') or os.path.join(os.getcwd(), 'data'),
         'tmpDir': os.environ.get('TD_TMP') or os.path.join(os.getcwd(), 'tmp'),
         'templateDir': os.path.join(_ROOT, 'templates'),
-        'cwDir': os.getcwd()
+        'cwDir': os.getcwd(),
+        'console': CONSOLE,
+        'stderr':  STDERR,
     }
     
     encoding = sys.stdout.encoding
+
     if str(sys.stdout.encoding).upper() != 'UTF-8':
-        
-        def uprint(self, *args, **kwargs):
+        def uprint(self, *args, stderr: bool = False, style: str = None, **kwargs) -> None:
+            """ unicode-handling print: when the stdout stream is not utf-8 supporting,
+                we do a little extra io work to ensure users don't get confusing unicode
+                errors. When the output stream *is* utf-8, tradeenv replaces this method
+                with a less expensive method.
+                :param stderr: report to stderr instead of stdout
+                :param style: specify a 'rich' console style to use when the stream supports it
+            """
+            console = self.stderr if stderr else self.console
             try:
-                print(*args, **kwargs)
+                # Attempt to print; the 'file' argument isn't spuported by rich, so we'll
+                # need to fall-back on old print when someone specifies it.
+                console.print(*args, style=style, **kwargs)
+
             except UnicodeEncodeError as e:
+                # Characters in the output couldn't be translated to unicode.
                 if not self.quiet:
-                    print(
-                        "CAUTION: Your terminal/console couldn't handle some "
+                    self.stderr.print(
+                        "[orange3][bold]CAUTION: Your terminal/console couldn't handle some "
                         "text I tried to print."
                     )
                     if 'EXCEPTIONS' in os.environ:
                         traceback.print_exc()
                     else:
-                        print(str(e))
+                        self.stderr.print(e)
+
+                # Try to translate each ary into a viable stirng using utf error-replacement.
                 strs = [
-                    str(arg).
-                        encode(TradeEnv.encoding, errors = 'replace').
-                        decode(TradeEnv.encoding)
+                    str(arg)
+                        .encode(TradeEnv.encoding, errors="replace")
+                        .decode(TradeEnv.encoding)
                     for arg in args
                 ]
-                print(*strs, **kwargs)
+                console.print(*strs, style=style, **kwargs)
     
     else:
-        uprint = print
+        def uprint(self, *args, stderr: bool = False, style: str = None, **kwargs) -> None:
+            """ unicode-handling print: when the stdout stream is not utf-8 supporting,
+                this method is replaced with one that tries to provide users better support
+                when a unicode error appears in the wild.
+
+                :param file: [optional] stream to write to (disables styles/rich support)
+                :param style: [optional] specify a rich style for the output text
+            """
+            console = self.stderr if stderr else self.console
+            console.print(*args, style=style, **kwargs)
     
-    def __init__(self, properties = None, **kwargs):
-        properties = properties or dict()
+
+    def __init__(self, properties: Optional[Union[argparse.Namespace, Dict]] = None, **kwargs) -> None:
+        # Inject the defaults into ourselves in a dict-like way
         self.__dict__.update(self.defaults)
-        if properties:
-            self.__dict__.update(properties.__dict__)
-        if kwargs:
-            self.__dict__.update(kwargs)
-    
-    def __getattr__(self, key):
+
+        # If properties is a namespace, extract the dictionary; otherwise use it as-is
+        if properties and hasattr(properties, '__dict__'):  # which arparse.Namespace has
+            properties = properties.__dict__
+        # Merge into our dictionary
+        self.__dict__.update(properties or {})
+
+        # Merge the kwargs dictionary
+        self.__dict__.update(kwargs or {})
+
+        # When debugging has been enabled on startup, enable slightly more
+        # verbose rich backtraces.
+        if self.__dict__['debug']:
+            install_rich_traces(console=STDERR, show_locals=True, extra_lines=2)
+
+    def __getattr__(self, key: str) -> Any:
         """ Return the default for attributes we don't have """
+
+        # The first time the DEBUG attribute is referenced, register a method for it.
         if key.startswith("DEBUG"):
             
             # Self-assembling DEBUGN functions
             def __DEBUG_ENABLED(outText, *args, **kwargs):
-                print('#', outText.format(*args, **kwargs))
+                # Give debug output a less contrasted color.
+                self.console.print(f"[dim]#{outText.format(*args, **kwargs)}[/dim]")
             
             def __DEBUG_DISABLED(*args, **kwargs):
                 pass
@@ -96,10 +161,11 @@ class TradeEnv(object):
         
         if key == "NOTE":
             
-            def __NOTE_ENABLED(outText, *args, file = None, **kwargs):
+            def __NOTE_ENABLED(outText, *args, stderr: bool = False, **kwargs):
                 self.uprint(
                     "NOTE:", str(outText).format(*args, **kwargs),
-                    file = file,
+                    style="bold",
+                    stderr=stderr,
                 )
             
             def __NOTE_DISABLED(*args, **kwargs):
@@ -115,10 +181,11 @@ class TradeEnv(object):
         
         if key == "WARN":
             
-            def _WARN_ENABLED(outText, *args, file = None, **kwargs):
+            def _WARN_ENABLED(outText, *args, stderr: bool = False, **kwargs):
                 self.uprint(
                     "WARNING:", str(outText).format(*args, **kwargs),
-                    file = file
+                    style="orange3",
+                    stderr=stderr,
                 )
             
             def _WARN_DISABLED(*args, **kwargs):


### PR DESCRIPTION
This change enables features of Python's "rich" text manipulation library, which provides a provides things like spinners, progress bars, but most importantly console-aware colorization and markup.

One of the nicer aspects of Rich is that it's designed for console applications like TD which want to retain automation support; you don't have to write everything as multiple branches to say "if we're not output to a console, work like this", etc.

With this change we will immediately get things like native colorization of links in the output to console, some syntax highlighting in things like the exporters etc, and my change also makes it so that:
a- DEBUGn lines are dimmed to make them less intrusive,
b- NOTE lines are boldened to make them stand out,
c- WARNING lines are colored orange,
