### PR TITLE
chore: tox test environments dev-requirements

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,9 @@
 [tox]
-envlist = py37,py38,py39,py310,py311
+envlist = flake8,py37,py38,py39,py310,py311
 
 [testenv]
 deps =
-    pytest
-    coverage
+	-r requirements/dev.txt
 commands=
     coverage run --source=tradedangerous -m pytest {posargs}
     coverage report --show-missing


### PR DESCRIPTION
The tox testenv's need to import the same set of packages as dependencies that trade is going to want. using "-r requirements/dev.txt" tells it to do this.

I also added "flake8" as an env so that you can use tox to get flake results with `tox -e flake8`; the value there is that you get apples-to-apples. I hate running flake in my ide / vim and then tox has a slightly different config :)