### PR TITLE
refactor: requests is installed by requirements

### DIFF
--- a/tradedangerous/misc/edsc.py
+++ b/tradedangerous/misc/edsc.py
@@ -4,19 +4,7 @@ from collections import namedtuple
 from urllib.request import Request, urlopen
 
 import json
-
-try:
-    import requests
-except ImportError as e:
-    import pip
-    print("ERROR: Unable to load the Python 'requests' package.")
-    approval = input(
-        "Do you want me to try and install it with the package manager (y/n)? "
-    )
-    if approval.lower() != 'y':
-        raise e
-    pip.main(["install", "--upgrade", "requests"])
-    import requests
+import requests
 
 
 def edsc_log(apiCall, params, jsonData=None, error=None):

--- a/tradedangerous/misc/edsm.py
+++ b/tradedangerous/misc/edsm.py
@@ -6,19 +6,7 @@ uses EDSM - https://www.edsm.net/api
 """
 
 import json
-
-try:
-    import requests
-except ImportError as e:
-    import pip
-    print("ERROR: Unable to load the Python 'requests' package.")
-    approval = input(
-        "Do you want me to try and install it with the package manager (y/n)? "
-    )
-    if approval.lower() != 'y':
-        raise e
-    pip.main(["install", "--upgrade", "requests"])
-    import requests
+import requests
 
 
 def edsm_log(apiCall, url, params, jsonData=None, error=None):

--- a/tradedangerous/submit-distances.py
+++ b/tradedangerous/submit-distances.py
@@ -16,6 +16,7 @@ import argparse
 import os
 import random
 import re
+import requests
 import sys
 import tradedb
 import tradeenv
@@ -23,30 +24,6 @@ import tradeenv
 from misc.edsc import StarSubmission, StarSubmissionResult, SubmissionError
 from misc.clipboard import SystemNameClip
 
-try:
-    import requests
-except ImportError as e:
-    print("""ERROR: Unable to load the Python 'requests' package.
-
-This script uses a Python module/package called 'requests' to allow
-it to talk to the EDSC web service. This package is not installed
-by default, but it can be installed with Python's package manager (pip).
-
-You can either install/update it yourself, e.g.:
-  
-  pip install --upgrade requests
-
-or if you like, I can try and install it for you now
-""")
-    approval = input(
-        "Do you want me to try and install it with the package manager (y/n)? "
-    )
-    if approval.lower() != 'y':
-        print("You didn't type 'y' so I'm giving up.")
-        raise e
-    import pip
-    pip.main(["install", "--upgrade", "requests"])
-    import requests  # noqa: F401
 
 standardStars = [
     "SOL",


### PR DESCRIPTION
All of this code is present just to try and automate the installation of requests if it's not already present, and history suggests this has been problematic for people over time.

The code is there because we didn't have requirements.txt or users who knew how to pip install things, so it's entirely redundant now.
