### PR TITLE
Fix lint and encoding

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -130,6 +130,8 @@ deps =
 	-r requirements-dev.txt
 commands =
 	pylint --rcfile {toxinidir}/tox.ini \
+		trade.py \
+		tradegui.py \
 		tradedangerous/__init__.py \
 		tradedangerous/cache.py \
 		tradedangerous/cli.py \
@@ -139,11 +141,9 @@ commands =
 		tradedangerous/fs.py \
 		tradedangerous/prices.py \
 		tradedangerous/tools.py \
-		tradedangerous/trade.py \
 		tradedangerous/tradecalc.py \
 		tradedangerous/tradedb.py \
 		tradedangerous/tradeenv.py \
-		tradedangerous/tradegui.py \
 		tradedangerous/transfers.py \
 		tradedangerous/utils.py \
 		tradedangerous/version.py \

--- a/trade.py
+++ b/trade.py
@@ -35,10 +35,10 @@
 # to empower other programmers to do cool stuff.
 from tradedangerous import cli
 
+import sys
+
 def main(argv = None):
-  import sys
-  cli.main(sys.argv)
+    cli.main(sys.argv)
 
 if __name__ == "__main__":
-  import sys
-  cli.main(sys.argv)
+    cli.main(sys.argv)

--- a/tradedangerous/plugins/eddblink_plug.py
+++ b/tradedangerous/plugins/eddblink_plug.py
@@ -181,7 +181,7 @@ class ImportPlugin(plugins.ImportPluginBase):
         # Use an HTTP Request header to obtain the Last-Modified and Content-Length headers.
         # Also, tell the server to give us the un-compressed length of the file by saying
         # that >this< request only wants text.
-        headers = {"User-Agent": "Trade-Dangerous", "Accept-Encoding": "text"}
+        headers = {"User-Agent": "Trade-Dangerous", "Accept-Encoding": "identity"}
         try:
             response = requests.head(url, headers=headers, timeout=70)
         except Exception as e:  # pylint: disable=broad-exception-caught


### PR DESCRIPTION
- cleanup: 2-space indentation and localized imports in trade.py annoyed pylint,
- noted in #126 that 'text' is not a legal Accept-Encoding, using identity instead should avoid later issues