### PR TITLE
fix: typo caused buy command to error

### DIFF
--- a/tradedangerous/commands/buy_cmd.py
+++ b/tradedangerous/commands/buy_cmd.py
@@ -412,5 +412,5 @@ def render(results, cmdenv, tdb):
         print(stnRowFmt.format(row))
     
     if singleMode and cmdenv.detail:
-        msg = "-- Ship Cost" if mode is SHIP_MODE else "-- Average",
+        msg = "-- Ship Cost" if mode is SHIP_MODE else "-- Average"
         print(f"{msg:{maxStnLen}} {results.summary.avg:>10n}")


### PR DESCRIPTION
- the code that should render the Average line at the end of a buy report had a typo that caused a string to become a list of strings, and the subsequent code could not handle that.

fixes issue #153 