### PR TITLE
chore: fix github actions cache warnings

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -45,14 +45,14 @@ jobs:
         python-version: ${{ matrix.py }}
 
     - name: Cache python packages
-      uses: actions/cache@v3
+      uses: actions/cache@v4.0.2
       with:
         path: ~/.cache/pip
         key: ${{ runner.os }}-pip-${{ hashFiles('requirements*.txt') }}
         restore-keys: ${{ runner.os }}-pip-
 
     - name: Cache tox results
-      uses: actions/cache@v3
+      uses: actions/cache@v4.0.2
       with:
         path: .tox
         key: ${{ runner.os }}-${{ matrix.py }}-tox-${{ hashFiles('tox.ini') }}-${{ hashFiles('requirements*.txt') }}


### PR DESCRIPTION
I'd used an older github actions of mine as a basis for the cache blocks, and they referenced an out-of-date cache version.

contributes to #147