### PR TITLE
feat: Begin replacing old progress bars with Rich bars

### DIFF
--- a/tradedangerous/cache.py
+++ b/tradedangerous/cache.py
@@ -40,8 +40,7 @@ from . import prices
 
 # For mypy/pylint type checking
 if typing.TYPE_CHECKING:
-    from collections.abc import Callable
-    from typing import Any, Optional, TextIO
+    from typing import Any, Callable, Optional, TextIO  # noqa
     
     from .tradeenv import TradeEnv
 

--- a/tradedangerous/formatting.py
+++ b/tradedangerous/formatting.py
@@ -8,8 +8,7 @@ import itertools
 import typing
 
 if typing.TYPE_CHECKING:
-    from typing import Any, Optional
-    from collections.abc import Callable
+    from typing import Any, Callable, Optional  # noqa
 
 
 class ColumnFormat:

--- a/tradedangerous/misc/progress.py
+++ b/tradedangerous/misc/progress.py
@@ -1,71 +1,116 @@
-import sys
+from rich.progress import (
+        Progress as RichProgress,
+        BarColumn, DownloadColumn, MofNCompleteColumn, SpinnerColumn, 
+        TaskProgressColumn, TextColumn, TimeElapsedColumn, TimeRemainingColumn,
+        TransferSpeedColumn
+)
+
+from typing import Optional
+
+
+class BarStyle:
+    """ Base class for Progress bar style types. """
+    def __init__(self, width: int=10, prefix: Optional[str] = None):
+        self.columns = [SpinnerColumn()]
+        if prefix is not None:
+            self.columns += [TextColumn(prefix)]
+        self.columns += [BarColumn(bar_width=width)]
+        self.columns += [TaskProgressColumn()]
+        self.columns += [TimeElapsedColumn()]
+
+
+class CountingBar(BarStyle):
+    """ Creates a progress bar that is counting M/N items to completion. """
+    def __init__(self, width: int=10, prefix: Optional[str] = None):
+        self.columns = [SpinnerColumn()]
+        if prefix is not None:
+            self.columns += [TextColumn(prefix)]
+        self.columns += [BarColumn(bar_width=width)]
+        self.columns += [MofNCompleteColumn()]
+        self.columns += [TimeElapsedColumn()]
+
+
+class DefaultBar(BarStyle):
+    """ Creates a simple default progress bar with a percentage and time elapsed. """
+    pass
+
+
+class TransferBar(BarStyle):
+    """ Creates a progress bar representing a data transfer, which shows the amount of
+        data transferred, speed, and estimated time remaining. """
+    def __init__(self, width: int=16, prefix: Optional[str] = None):
+        self.columns = (
+            SpinnerColumn(),
+            TextColumn(prefix),
+            BarColumn(bar_width=width),
+            DownloadColumn(),
+            TransferSpeedColumn(),
+            TimeRemainingColumn(),
+        )
+
 
 class Progress:
     """
-    Helper class that describes a simple text-based progress bar.
+    Facade around the rich Progress bar system to help transition away from
+    TD's original basic progress bar implementation.
     """
-    
-    def __init__(self, maxValue, width, start=0, prefix=""):
+    def __init__(self, max_value: float, width: int, start: float = 0, prefix: str = "", *, style: BarStyle = DefaultBar) -> None:
         """
-        Arguments:
-            maxValue
-                Last value we can reach (100%).
-            width
-                Number of '='s characters for 100%
-            start
-                Initial value
-            prefix
-                Something to print infront of the progress bar
+            :param max_value: Last value we can reach (100%).
+            :param width:     How wide to make the bar itself.
+            :param start:     Override initial value to non-zero.
+            :param prefix:    Text to print between the spinner and the bar.
         """
-        self.start = start
-        self.maxValue = maxValue
-        self.width = width
+        self.max_value = 0 if max_value is None else max(max_value, start)
         self.value = start
-        self.progress = -1
         self.prefix = prefix
-        self.textLen = 0
-        self.mask = '\r' + self.prefix + "[{{:<{width}}}]".format(width=width)
+        self.width = width
+        
+        # The 'Progress' itself is a view for displaying the progress of tasks. So we construct it
+        # and then create a task for our job.
+        self.progress = RichProgress(
+            # What fields to display.
+            *style(width=self.width, prefix=self.prefix).columns,
+            # Hide it once it's finished, update it for us, 4x a second
+            transient=True, auto_refresh=True, refresh_per_second=4
+        )
 
+        # Now we add an actual task to track progress on.
+        self.task = self.progress.add_task("Working...", total=max_value, start=True)
+        if self.value:
+            self.progress.update(self.task, advance=self.value)
 
-    def increment(self, value, postfix=""):
-        """
-        Increment the progress bar's internal counter by 'value',
-        and if this changes the progress step, re-draw the bar.
-        
-        Attributes:
-            value
-                The amount to increment the internal counter by
-            postfix [optional]
-                String or callable to print after the bar
-        
-        Returns:
-            False if the progress bar did not redraw,
-            True if the progress bar was redrawn,
-        """
-        self.value = min(self.maxValue, self.value + value)
-        progress = int(self.width * (self.value - self.start) / self.maxValue)
-        if progress == self.progress:
-            return False
-        
-        if callable(postfix):
-            postfixText = postfix(self.value, self.maxValue)
-        else:
-            postfixText = postfix
-        text = self.mask.format("="*progress) + postfixText + " "
-        sys.stdout.write(text)
-        sys.stdout.flush()
-        
-        self.progress = progress
-        self.textLen = len(text)
-        
-        return True
+        # And show the task tracker.
+        self.progress.start()
 
+    def __enter__(self):
+        return self
 
-    def clear(self):
+    def __exit__(self, *args, **kwargs):
+        self.clear()
+
+    def increment(self, value: float, description: Optional[str] = None, *, postfix: str = "") -> None:
         """
-        Remove the current progress bar, if any
+        Increase the progress of the bar by a given amount.
+        
+        :param value:  How much to increase the progress by.
+        :param postfix: [deprecated] text added after the bar
+        :param description: If set, replaces the task description.
         """
-        if self.textLen:
-            fin = "\r{:{width}}\r".format('', width=self.textLen)
-            sys.stdout.write(fin)
-            sys.stdout.flush()
+        if description:
+            self.progress.update(self.task, description=description)
+        self.value += value              # Update our internal count
+        if self.value >= self.max_value:  # Did we go past the end? Increase the end.
+            self.max_value += value * 2
+            self.progress.update(self.task, total=self.max_value)
+        if self.max_value > 0:
+            self.progress.update(self.task, completed=self.value)
+
+    def clear(self) -> None:
+        """ Remove the current progress bar, if any. """
+        if self.task:
+            self.progress.remove_task(self.task)
+            self.task = None
+        if self.progress:
+            self.progress.stop()
+            self.progress = None

--- a/tradedangerous/misc/progress.py
+++ b/tradedangerous/misc/progress.py
@@ -1,52 +1,44 @@
 from rich.progress import (
         Progress as RichProgress,
+        TaskID,
+        ProgressColumn,
         BarColumn, DownloadColumn, MofNCompleteColumn, SpinnerColumn, 
         TaskProgressColumn, TextColumn, TimeElapsedColumn, TimeRemainingColumn,
         TransferSpeedColumn
 )
+from contextlib import contextmanager
 
-from typing import Optional
+from typing import Iterable, Optional, Type
 
 
 class BarStyle:
     """ Base class for Progress bar style types. """
-    def __init__(self, width: int=10, prefix: Optional[str] = None):
-        self.columns = [SpinnerColumn()]
-        if prefix is not None:
-            self.columns += [TextColumn(prefix)]
-        self.columns += [BarColumn(bar_width=width)]
-        self.columns += [TaskProgressColumn()]
-        self.columns += [TimeElapsedColumn()]
+    def __init__(self, width: int = 10, prefix: Optional[str] = None, *, add_columns: Optional[Iterable[ProgressColumn]]):
+        self.columns = [SpinnerColumn(), TextColumn(prefix), BarColumn(bar_width=width)]
+        if add_columns:
+            self.columns.extend(add_columns)
 
 
 class CountingBar(BarStyle):
     """ Creates a progress bar that is counting M/N items to completion. """
-    def __init__(self, width: int=10, prefix: Optional[str] = None):
-        self.columns = [SpinnerColumn()]
-        if prefix is not None:
-            self.columns += [TextColumn(prefix)]
-        self.columns += [BarColumn(bar_width=width)]
-        self.columns += [MofNCompleteColumn()]
-        self.columns += [TimeElapsedColumn()]
+    def __init__(self, width: int = 10, prefix: Optional[str] = None):
+        my_columns = [MofNCompleteColumn(), TimeElapsedColumn()]
+        super().__init__(width, prefix, add_columns=my_columns)
 
 
 class DefaultBar(BarStyle):
     """ Creates a simple default progress bar with a percentage and time elapsed. """
-    pass
+    def __init__(self, width: int = 10, prefix: Optional[str] = None):
+        my_columns = [TaskProgressColumn(), TimeElapsedColumn()]
+        super().__init__(width, prefix, add_columns=my_columns)
 
 
 class TransferBar(BarStyle):
     """ Creates a progress bar representing a data transfer, which shows the amount of
         data transferred, speed, and estimated time remaining. """
-    def __init__(self, width: int=16, prefix: Optional[str] = None):
-        self.columns = (
-            SpinnerColumn(),
-            TextColumn(prefix),
-            BarColumn(bar_width=width),
-            DownloadColumn(),
-            TransferSpeedColumn(),
-            TimeRemainingColumn(),
-        )
+    def __init__(self, width: int = 16, prefix: Optional[str] = None):
+        my_columns = [DownloadColumn(), TransferSpeedColumn(), TimeRemainingColumn()]
+        super().__init__(width, prefix, add_columns=my_columns)
 
 
 class Progress:
@@ -54,23 +46,40 @@ class Progress:
     Facade around the rich Progress bar system to help transition away from
     TD's original basic progress bar implementation.
     """
-    def __init__(self, max_value: float, width: int, start: float = 0, prefix: str = "", *, style: BarStyle = DefaultBar) -> None:
+    def __init__(self,
+                 max_value: Optional[float] = None,
+                 width: Optional[int] = None,
+                 start: float = 0,
+                 prefix: Optional[str] = None,
+                 *,
+                 style: Optional[Type[BarStyle]] = None,
+                 show: bool = True,
+                 ) -> None:
         """
             :param max_value: Last value we can reach (100%).
             :param width:     How wide to make the bar itself.
             :param start:     Override initial value to non-zero.
             :param prefix:    Text to print between the spinner and the bar.
+            :param style:     Bar-style factory to use for styling.
+            :param show:      If False, disables the bar entirely.
         """
+        self.show = bool(show)
+        if not show:
+            return
+
+        if style is None:
+            style = DefaultBar
+
         self.max_value = 0 if max_value is None else max(max_value, start)
         self.value = start
-        self.prefix = prefix
-        self.width = width
-        
+        self.prefix = prefix or ""
+        self.width = width or 25
         # The 'Progress' itself is a view for displaying the progress of tasks. So we construct it
         # and then create a task for our job.
+        style_instance = style(width=self.width, prefix=self.prefix)
         self.progress = RichProgress(
             # What fields to display.
-            *style(width=self.width, prefix=self.prefix).columns,
+            *style_instance.columns,
             # Hide it once it's finished, update it for us, 4x a second
             transient=True, auto_refresh=True, refresh_per_second=4
         )
@@ -84,33 +93,80 @@ class Progress:
         self.progress.start()
 
     def __enter__(self):
+        """ Context manager.
+        
+            Example use:
+
+                import time
+                import tradedangerous.progress
+
+                # Progress(max_value=100, width=32, style=progress.CountingBar)
+                with progress.Progress(100, 32, style=progress.CountingBar) as prog:
+                    for i in range(100):
+                        prog.increment(1)
+                        time.sleep(3)
+        """
         return self
 
     def __exit__(self, *args, **kwargs):
         self.clear()
 
-    def increment(self, value: float, description: Optional[str] = None, *, postfix: str = "") -> None:
+    def increment(self, value: Optional[float] = None, description: Optional[str] = None, *, progress: Optional[float] = None) -> None:
         """
         Increase the progress of the bar by a given amount.
         
         :param value:  How much to increase the progress by.
-        :param postfix: [deprecated] text added after the bar
         :param description: If set, replaces the task description.
+        :param progress: Instead of increasing by value, set the absolute progress to this.
         """
+        if not self.show:
+            return
         if description:
-            self.progress.update(self.task, description=description)
-        self.value += value              # Update our internal count
+            self.prefix = description
+            self.progress.update(self.task, description=description, refresh=True)
+        
+        bump = False
+        if not value and progress is not None and self.value != progress:
+            self.value = progress
+            bump = True
+        elif value:
+            self.value += value              # Update our internal count
+            bump = True
+
         if self.value >= self.max_value:  # Did we go past the end? Increase the end.
             self.max_value += value * 2
-            self.progress.update(self.task, total=self.max_value)
-        if self.max_value > 0:
-            self.progress.update(self.task, completed=self.value)
+            self.progress.update(self.task, description=self.prefix, total=self.max_value)
+            bump = True
+
+        if bump and self.max_value > 0:
+            self.progress.update(self.task, description=self.prefix, completed=self.value)
 
     def clear(self) -> None:
         """ Remove the current progress bar, if any. """
+        # These two shouldn't happen separately, but incase someone tinkers, test each
+        # separately and shut them down.
+        if not self.show:
+            return
+
         if self.task:
             self.progress.remove_task(self.task)
             self.task = None
+
         if self.progress:
             self.progress.stop()
             self.progress = None
+            
+    @contextmanager
+    def sub_task(self, description: str, max_value: Optional[int] = None, width: int = 25):
+        if not self.show:
+            yield
+            return
+        task = self.progress.add_task(description, total=max_value, start=True, width=width)
+        try:
+            yield task
+        finally:
+            self.progress.remove_task(task)
+
+    def update_task(self, task: TaskID, value: float, description: Optional[str] = None):
+        if self.show:
+            self.progress.update(task, value=value, description=description)

--- a/tradedangerous/misc/progress.py
+++ b/tradedangerous/misc/progress.py
@@ -34,6 +34,13 @@ class DefaultBar(BarStyle):
         super().__init__(width, prefix, add_columns=my_columns)
 
 
+class LongRunningCountBar(BarStyle):
+    """ Creates a progress bar that is counting M/N items to completion with a time-remaining counter """
+    def __init__(self, width: int = 10, prefix: Optional[str] = None):
+        my_columns = [MofNCompleteColumn(), TimeElapsedColumn(), TimeRemainingColumn()]
+        super().__init__(width, prefix, add_columns=my_columns)
+
+
 class TransferBar(BarStyle):
     """ Creates a progress bar representing a data transfer, which shows the amount of
         data transferred, speed, and estimated time remaining. """

--- a/tradedangerous/misc/progress.py
+++ b/tradedangerous/misc/progress.py
@@ -89,7 +89,7 @@ class Progress:
             # What fields to display.
             *style_instance.columns,
             # Hide it once it's finished, update it for us, 4x a second
-            transient=True, auto_refresh=True, refresh_per_second=4
+            transient=True, auto_refresh=True, refresh_per_second=5
         )
 
         # Now we add an actual task to track progress on.

--- a/tradedangerous/misc/progress.py
+++ b/tradedangerous/misc/progress.py
@@ -8,8 +8,7 @@ from rich.progress import (
 )
 from contextlib import contextmanager
 
-from collections.abc import Iterable
-from typing import Optional, Union
+from typing import Iterable, Optional, Union, Type  # noqa
 
 
 class BarStyle:
@@ -60,7 +59,7 @@ class Progress:
                  start: float = 0,
                  prefix: Optional[str] = None,
                  *,
-                 style: Optional[type[BarStyle]] = None,
+                 style: Optional[Type[BarStyle]] = None,
                  show: bool = True,
                  ) -> None:
         """

--- a/tradedangerous/misc/progress.py
+++ b/tradedangerous/misc/progress.py
@@ -8,13 +8,14 @@ from rich.progress import (
 )
 from contextlib import contextmanager
 
-from typing import Iterable, Optional, Type
+from collections.abc import Iterable
+from typing import Optional, Union
 
 
 class BarStyle:
     """ Base class for Progress bar style types. """
     def __init__(self, width: int = 10, prefix: Optional[str] = None, *, add_columns: Optional[Iterable[ProgressColumn]]):
-        self.columns = [SpinnerColumn(), TextColumn(prefix), BarColumn(bar_width=width)]
+        self.columns = [SpinnerColumn(), TextColumn("[progress.description]{task.description}"), BarColumn(bar_width=width)]
         if add_columns:
             self.columns.extend(add_columns)
 
@@ -52,7 +53,7 @@ class Progress:
                  start: float = 0,
                  prefix: Optional[str] = None,
                  *,
-                 style: Optional[Type[BarStyle]] = None,
+                 style: Optional[type[BarStyle]] = None,
                  show: bool = True,
                  ) -> None:
         """
@@ -167,6 +168,6 @@ class Progress:
         finally:
             self.progress.remove_task(task)
 
-    def update_task(self, task: TaskID, value: float, description: Optional[str] = None):
+    def update_task(self, task: TaskID, advance: Union[float, int], description: Optional[str] = None):
         if self.show:
-            self.progress.update(task, value=value, description=description)
+            self.progress.update(task, advance=advance, description=description)

--- a/tradedangerous/plugins/eddblink_plug.py
+++ b/tradedangerous/plugins/eddblink_plug.py
@@ -220,8 +220,8 @@ class ImportPlugin(plugins.ImportPluginBase):
         # to get any benefits from constructing transactions, and blowing up
         # the WAL and memory usage by making massive transactions.
         max_transaction_items, transaction_items = 32 * 1024, 0
-        with (pbar.Progress(total, 40, prefix="Processing", style=pbar.LongRunningCountBar) as prog,
-              listings_path.open("r", encoding="utf-8", errors="ignore") as fh):
+        with pbar.Progress(total, 40, prefix="Processing", style=pbar.LongRunningCountBar) as prog,\
+              listings_path.open("r", encoding="utf-8", errors="ignore") as fh:
             cursor = db.cursor()
             cursor.execute("BEGIN TRANSACTION")
             

--- a/tradedangerous/templates/TradeDangerous.sql
+++ b/tradedangerous/templates/TradeDangerous.sql
@@ -92,10 +92,9 @@ CREATE TABLE Station
    UNIQUE (station_id),
 
    FOREIGN KEY (system_id) REFERENCES System(system_id)
-    ON UPDATE CASCADE
     ON DELETE CASCADE
- );
-CREATE INDEX idx_station_by_system ON Station (system_id, station_id);
+ ) WITHOUT ROWID;
+CREATE INDEX idx_station_by_system ON Station (system_id);
 CREATE INDEX idx_station_by_name ON Station (name);
 
 
@@ -226,10 +225,44 @@ CREATE TABLE StationItem
     ON UPDATE CASCADE ON DELETE CASCADE,
   FOREIGN KEY (item_id) REFERENCES Item(item_id)
     ON UPDATE CASCADE ON DELETE CASCADE
-);
+) WITHOUT ROWID;
 CREATE INDEX si_mod_stn_itm ON StationItem(modified, station_id, item_id);
 CREATE INDEX si_itm_dmdpr ON StationItem(item_id, demand_price) WHERE demand_price > 0;
 CREATE INDEX si_itm_suppr ON StationItem(item_id, supply_price) WHERE supply_price > 0;
+
+-- Not used yet
+CREATE TABLE IF NOT EXISTS StationDemand
+(
+    station_id      INTEGER NOT NULL,
+    item_id         INTEGER NOT NULL,
+    price           INTEGER NOT NULL,
+    units           INTEGER NOT NULL,
+    level           INTEGER NOT NULL,
+    modified        INTEGER NOT NULL,
+    from_live       INTEGER NOT NULL DEFAULT 0,
+    CONSTRAINT pk_StationDemand PRIMARY KEY (station_id, item_id),
+    CONSTRAINT fk_StationDemand_station_id_Station FOREIGN KEY (station_id) REFERENCES Station (station_id) ON DELETE CASCADE,
+    CONSTRAINT fk_StationDemand_item_id_Item       FOREIGN KEY (item_id)    REFERENCES Item    (item_id)    ON DELETE CASCADE
+) WITHOUT ROWID;
+DELETE FROM StationDemand;
+CREATE INDEX idx_StationDemand_item ON StationDemand (item_id);
+
+-- Not used yet
+CREATE TABLE IF NOT EXISTS StationSupply
+(
+    station_id      INTEGER NOT NULL,
+    item_id         INTEGER NOT NULL,
+    price           INTEGER NOT NULL,
+    units           INTEGER NOT NULL,
+    level           INTEGER NOT NULL,
+    modified        INTEGER NOT NULL,
+    from_live       INTEGER NOT NULL DEFAULT 0,
+    CONSTRAINT pk_StationSupply PRIMARY KEY (station_id, item_id),
+    CONSTRAINT fk_StationSupply_station_id_Station FOREIGN KEY (station_id) REFERENCES Station (station_id) ON DELETE CASCADE,
+    CONSTRAINT fk_StationSupply_item_id_Item       FOREIGN KEY (item_id)    REFERENCES Item    (item_id)    ON DELETE CASCADE
+) WITHOUT ROWID;
+DELETE FROM StationSupply;
+CREATE INDEX idx_StationSupply_item ON StationSupply (item_id);
 
 CREATE VIEW StationBuying AS
 SELECT  station_id,

--- a/tradedangerous/transfers.py
+++ b/tradedangerous/transfers.py
@@ -17,7 +17,8 @@ import requests
 if typing.TYPE_CHECKING:
     import os  # for PathLike
     from .tradeenv import TradeEnv
-    from typing import Callable, Optional, Union
+    from collections.abc import Callable
+    from typing import Optional, Union
 
 
 ######################################################################
@@ -53,7 +54,7 @@ def download(
             backup:     bool = False,
             shebang:    Optional[Callable] = None,
             chunkSize:  int = 4096,
-            timeout:    int = 90,
+            timeout:    int = 30,
             *,
             length:     Optional[Union[int, str]] = None,
             session:    Optional[requests.Session] = None,
@@ -168,18 +169,12 @@ def get_json_data(url, *, timeout: int = 90):
     else:
         totalLength = int(totalLength)
         filename = get_filename_from_url(url)
-        progBar = pbar.Progress(totalLength, 25, style=pbar.DefaultBar, prefix=filename)
+        progBar = pbar.Progress(totalLength, 25, prefix=filename)
 
         jsData = bytes()
         for data in req.iter_content():
             jsData += data
-            progBar.increment(
-                len(data),
-                postfix=lambda value, goal: \
-                " {}/{}".format(
-                    makeUnit(value),
-                    makeUnit(goal),
-            ))
+            progBar.increment(len(data))
         progBar.clear()
     
     return json.loads(jsData.decode())

--- a/tradedangerous/transfers.py
+++ b/tradedangerous/transfers.py
@@ -17,8 +17,7 @@ import requests
 if typing.TYPE_CHECKING:
     import os  # for PathLike
     from .tradeenv import TradeEnv
-    from collections.abc import Callable
-    from typing import Optional, Union
+    from typing import Callable, Optional, Union  # noqa
 
 
 ######################################################################


### PR DESCRIPTION
- leverages the previously built 'rich' integration,
- exposes several types of progress bar,
- provides a contextmanager method for wrapping work with progress bars,
- progress updates are asynchronous so they don't slow down processing so much,
- integrates the progress bars with cache building and downloads,
- some perf tweaks to Station imports,
- some perf tweaks to eddblink prices imports (may need further tuning),
- calling self.tdenv.DEBUGX adds up to about ~2s of processing time when importing prices, because of python call overhead so I put it behind a conditional,
- fixed some linting and other minor issues,
- minor tidy up
- add StationDemand and StationSupply tables for future use
- * an initial test importing to these tables instead of StationItem reduced clean EDDB import from ~30 minutes to 5.

Suggest you try running this a few times to decide if you like how the bars look, where they're used, etc.

Once this is landed, I'm going to finish off changes to eddblink that reduces the time it takes to collect all the "is this file out of date?" by doing them over a single HTTPS connection.