### PR TITLE
Multiprocessing PoC

### DIFF
--- a/tradedangerous/commands/commandenv.py
+++ b/tradedangerous/commands/commandenv.py
@@ -65,12 +65,8 @@ class CommandEnv(TradeEnv):
                                 cwdPath, self.cwd)
         if self.cwd:
             os.chdir(self.cwd)
-    
-    def run(self, tdb):
-        """
-            Set the current database context for this env and check that
-            the properties we have are valid.
-        """
+            
+    def initAndCheckParams(self, tdb):
         self.tdb = tdb
         db_change = pathlib.Path(self.tdb.templatePath, 'database_changes.json')
         if pathlib.Path.exists(db_change):
@@ -81,7 +77,7 @@ class CommandEnv(TradeEnv):
                         self.tdb.getDB().execute(change)
             finally:
                 db_change.unlink()
-        
+                
         self.checkMFD()
         self.checkFromToNear()
         self.checkAvoids()
@@ -90,6 +86,14 @@ class CommandEnv(TradeEnv):
         self.checkPlanetary()
         self.checkFleet()
         self.checkOdyssey()
+    
+    def run(self, tdb):
+        """
+            Set the current database context for this env and check that
+            the properties we have are valid.
+        """
+
+        self.initAndCheckParams(tdb)
         
         results = CommandResults(self)
         return self._cmd.run(results, self, tdb)

--- a/tradedangerous/commands/run_cmd.py
+++ b/tradedangerous/commands/run_cmd.py
@@ -1,3 +1,8 @@
+import multiprocessing
+from concurrent import futures
+from concurrent.futures.process import ProcessPoolExecutor
+from concurrent.futures.thread import ThreadPoolExecutor
+
 from .commandenv import ResultRow
 from .exceptions import CommandLineError, NoDataError
 from .parsing import (
@@ -7,7 +12,9 @@ from .parsing import (
 )
 from itertools import chain
 from ..tradedb import TradeDB, System, Station, describeAge
-from ..tradecalc import TradeCalc, Route, NoHopsError
+from ..tradecalc import TradeCalc, Route, JarredRoute, JarredPlace
+from tradedangerous.misc import progress as pbar
+from tradedangerous.tradecalcchunk import run_route, init_tradecalcchunk, init_calctradechunk_thread
 
 import math
 import sys
@@ -1211,6 +1218,10 @@ def run(results, cmdenv, tdb):
         maxHopDistLy = cmdenv.maxJumpsPer * cmdenv.maxLyPer
         if not cmdenv.loop:
             stopSystems = {stop.system for stop in stopStations}
+
+    workers_count = 4
+    executor = ProcessPoolExecutor(max_workers=workers_count, initializer=init_tradecalcchunk, mp_context=multiprocessing.get_context('spawn'))
+    # executor = ThreadPoolExecutor(max_workers=workers_count, initializer=init_calctradechunk_thread, initargs=(calc,))
     
     for hopNo in range(numHops):
         restrictTo = None
@@ -1257,9 +1268,51 @@ def run(results, cmdenv, tdb):
         elif cmdenv.debug:
             cmdenv.DEBUG0("Hop {}...", hopNo + 1)
         
-        try:
-            newRoutes = calc.getBestHops(routes, restrictTo = restrictTo)
-        except NoHopsError:
+        with pbar.Progress(max_value=len(routes), width=25, show=tdb.tdenv.progress) as prog:
+            jarredRoutes = list(map(lambda rt: JarredRoute(rt), routes))
+            
+            jarredRestrictTo = None
+            if restrictTo is not None:
+                jarredRestrictTo = list(map(lambda p: JarredPlace(p), restrictTo))
+            
+            def chunk_list(lst, chunk_size):
+                for i in range(0, len(lst), chunk_size):
+                    yield lst[i:i + chunk_size]
+
+            notDoneFutures = list(map(lambda rts: executor.submit(run_route, rts, restrictTo=jarredRestrictTo), chunk_list(jarredRoutes, 100)))
+            bestToDest = {}
+            while len(notDoneFutures) > 0:
+                doneFutures, notDoneFutures = futures.wait(notDoneFutures, return_when=futures.FIRST_COMPLETED)
+                
+                for done in doneFutures:
+                    prog.increment(100)
+                    future_result = map(lambda rt: rt.toNormalRoute(tdb), done.result())
+                    for route in future_result:
+                        dstID = route.lastStation.ID
+                        try:
+                            # See if there is already a candidate for this destination
+                            btd = bestToDest[dstID]
+                        except KeyError:
+                            # No existing candidate, we win by default
+                            pass
+                        else:
+                            # Check if it is a better option than we just produced
+                            bestTradeScore = btd.score
+                            currentTradeScore = route.score
+                            if bestTradeScore > currentTradeScore:
+                                continue
+                            if bestTradeScore == currentTradeScore:
+                                bestLy = btd.firstStation.system.distanceTo(route.lastStation.system)
+                                currentLy = route.firstStation.system.distanceTo(route.lastStation.system)
+                                if bestLy <= currentLy:
+                                    continue
+    
+                        bestToDest[dstID] = route
+            
+
+        newRoutes = list(bestToDest.values())
+
+        if len(newRoutes) == 0:
             if hopNo == 0 and len(cmdenv.origSystems) == 1:
                 raise NoDataError(
                     "Couldn't find any trading links within {} x {}ly jumps of {}."

--- a/tradedangerous/tradecalc.py
+++ b/tradedangerous/tradecalc.py
@@ -490,6 +490,69 @@ class Route:
             )
         )
 
+class JarredRoute:
+    __slots__ = ('route', 'hops', 'startCr', 'gainCr', 'jumps', 'score')
+    
+    def __init__(self, route):
+        self.route = tuple(map(lambda s:s.ID, route.route))
+        def mapHop(load):
+            newTradeCountTuples = []
+            for tradeCountTuple in load.items:
+                trade = tradeCountTuple[0]._replace(item=tradeCountTuple[0].item.ID)
+                count = tradeCountTuple[1]
+                newTradeCountTuples.append((trade, count))
+            return load._replace(items=newTradeCountTuples)
+        
+        self.hops = tuple(map(mapHop, route.hops))
+        self.startCr = route.startCr
+        self.gainCr = route.gainCr
+        
+        def mapJump(jumps):
+            newJumps = []
+            for jump in jumps:
+                newJumps.append(jump.ID)
+            return newJumps
+        
+        self.jumps = tuple(map(mapJump, route.jumps))
+        self.score = route.score
+        
+    def toNormalRoute(self, tdb):
+        route = tuple(map(lambda stID:tdb.stationByID[stID], self.route))
+        def unmapHop(load):
+            oldTradeCountTuples = []
+            for tradeCountTuple in load.items:
+                trade = tradeCountTuple[0]._replace(item=tdb.itemByID[tradeCountTuple[0].item])
+                count = tradeCountTuple[1]
+                oldTradeCountTuples.append((trade, count))
+            return load._replace(items=oldTradeCountTuples)
+        
+        hops = tuple(map(unmapHop, self.hops))
+        
+        def unmapJump(jumps):
+            oldJumps = []
+            for sysID in jumps:
+                oldJumps.append(tdb.systemByID[sysID])
+            return oldJumps
+        
+        jumps = tuple(map(unmapJump, self.jumps))
+
+        return Route(route, hops, self.startCr, self.gainCr, jumps, self.score)
+    
+class JarredPlace:
+    __slots__ = ('place',)
+    
+    def __init__(self, place):
+        if type(place) is System:
+            self.place = ('system', place.ID)
+        if type(place) is Station:
+            self.place = ('station', place.ID)
+        
+    def toNormalPlace(self, tdb):
+        if self.place[0] == 'system':
+            return tdb.systemByID[self.place[1]]
+        if self.place[0] == 'station':
+            return tdb.stationByID[self.place[1]]
+        
 
 class TradeCalc:
     """
@@ -850,6 +913,11 @@ class TradeCalc:
         """
         
         tdb = self.tdb
+        routes = list(map(lambda rt: rt.toNormalRoute(tdb), routes))
+
+        if restrictTo is not None:
+            restrictTo = set(map(lambda p: p.toNormalPlace(tdb), restrictTo))
+        
         tdenv = self.tdenv
         avoidPlaces = getattr(tdenv, 'avoidPlaces', None) or ()
         assert not restrictTo or isinstance(restrictTo, set)
@@ -930,180 +998,180 @@ class TradeCalc:
                     odyssey = odyssey,
                 )
         
-        with pbar.Progress(max_value=len(routes), width=25, show=tdenv.progress) as prog:
-            connections = 0
-            getSelling = self.stationsSelling.get
-            for route_no, route in enumerate(routes):
-                prog.increment(progress=route_no)
-                tdenv.DEBUG1("Route = {}", route.text(lambda x, y: y))
+        # with pbar.Progress(max_value=len(routes), width=25, show=False) as prog:
+        connections = 0
+        getSelling = self.stationsSelling.get
+        for route_no, route in enumerate(routes):
+            # prog.increment(progress=route_no)
+            tdenv.DEBUG1("Route = {}", route.text(lambda x, y: y))
+            
+            srcStation = route.lastStation
+            startCr = credits + int(route.gainCr * safetyMargin)
+            
+            srcSelling = getSelling(srcStation.ID, None)
+            srcSelling = tuple(
+                values for values in srcSelling
+                if values[1] <= startCr
+            )
+            if not srcSelling:
+                tdenv.DEBUG1("Nothing sold/affordable - next.")
+                continue
+            
+            if goalSystem:
+                origSystem = route.firstSystem
+                srcSystem = srcStation.system
+                srcDistTo = srcSystem.distanceTo
+                goalDistTo = goalSystem.distanceTo
+                origDistTo = origSystem.distanceTo
+                srcGoalDist = srcDistTo(goalSystem)
+                srcOrigDist = srcDistTo(origSystem)
+                origGoalDist = origDistTo(goalSystem)
+            
+            if unique:
+                uniquePath = route.route
+            elif loopInt:
+                pos_from_end = 0 - loopInt
+                uniquePath = route.route[pos_from_end:-1]
+            
+            stations = (d for d in station_iterator(srcStation)
+            if (d.station != srcStation) and
+                (d.station.blackMarket == 'Y' if reqBlackMarket else True) and
+                (d.station not in uniquePath if uniquePath else True) and
+                (d.station in restrictStations if restrictStations else True) and
+                (d.station.dataAge and d.station.dataAge <= maxAge if maxAge else True) and
+                (((d.system is not srcSystem) if bool(tdenv.unique) else (d.system is goalSystem or d.distLy < srcGoalDist)) if goalSystem else True)
+            )
+            
+            if tdenv.debug >= 1:
                 
-                srcStation = route.lastStation
-                startCr = credits + int(route.gainCr * safetyMargin)
-                
-                srcSelling = getSelling(srcStation.ID, None)
-                srcSelling = tuple(
-                    values for values in srcSelling
-                    if values[1] <= startCr
-                )
-                if not srcSelling:
-                    tdenv.DEBUG1("Nothing sold/affordable - next.")
-                    continue
-                
-                if goalSystem:
-                    origSystem = route.firstSystem
-                    srcSystem = srcStation.system
-                    srcDistTo = srcSystem.distanceTo
-                    goalDistTo = goalSystem.distanceTo
-                    origDistTo = origSystem.distanceTo
-                    srcGoalDist = srcDistTo(goalSystem)
-                    srcOrigDist = srcDistTo(origSystem)
-                    origGoalDist = origDistTo(goalSystem)
-                
-                if unique:
-                    uniquePath = route.route
-                elif loopInt:
-                    pos_from_end = 0 - loopInt
-                    uniquePath = route.route[pos_from_end:-1]
-                
-                stations = (d for d in station_iterator(srcStation)
-                if (d.station != srcStation) and
-                    (d.station.blackMarket == 'Y' if reqBlackMarket else True) and
-                    (d.station not in uniquePath if uniquePath else True) and
-                    (d.station in restrictStations if restrictStations else True) and
-                    (d.station.dataAge and d.station.dataAge <= maxAge if maxAge else True) and
-                    (((d.system is not srcSystem) if bool(tdenv.unique) else (d.system is goalSystem or d.distLy < srcGoalDist)) if goalSystem else True)
-                )
-                
-                if tdenv.debug >= 1:
-                    
-                    def annotate(dest):
-                        tdenv.DEBUG1(
-                            "destSys {}, destStn {}, jumps {}, distLy {}",
-                            dest.system.dbname,
-                            dest.station.dbname,
-                            "->".join(jump.text() for jump in dest.via),
-                            dest.distLy
-                        )
-                        return True
-                    
-                    stations = (d for d in stations if annotate(d))
-                
-                for dest in stations:
-                    dstStation = dest.station
-                    
-                    connections += 1
-                    items = self.getTrades(srcStation, dstStation, srcSelling)
-                    if not items:
-                        continue
-                    trade = fitFunction(items, startCr, capacity, maxUnits)
-                    
-                    multiplier = 1.0
-                    # Calculate total K-lightseconds supercruise time.
-                    # This will amortize for the start/end stations
-                    dstSys = dest.system
-                    if goalSystem and dstSys is not goalSystem:
-                        dstGoalDist = goalDistTo(dstSys)
-                        # Biggest reward for shortening distance to goal
-                        score = 5000 * origGoalDist / dstGoalDist
-                        # bias towards bigger reductions
-                        score += 50 * srcGoalDist / dstGoalDist
-                        # discourage moving back towards origin
-                        if dstSys is not origSystem:
-                            score += 10 * (origDistTo(dstSys) - srcOrigDist)
-                        # Gain per unit pays a small part
-                        score += (trade.gainCr / trade.units) / 25
-                    else:
-                        score = trade.gainCr
-                    if lsPenalty:
-                        # [kfsone] Only want 1dp
-                        
-                        cruiseKls = int(dstStation.lsFromStar / 100) / 10
-                        # Produce a curve that favors distances under 1kls
-                        # positively, starts to penalize distances over 1k,
-                        # and after 4kls starts to penalize aggressively
-                        # http://goo.gl/Otj2XP
-                        
-                        # [eyeonus] As aadler pointed out, this goes into negative
-                        # numbers, which causes problems.
-                        # penalty = ((cruiseKls ** 2) - cruiseKls) / 3
-                        # penalty *= lsPenalty
-                        # multiplier *= (1 - penalty)
-                        
-                        # [eyeonus]:
-                        # (Keep in mind all this ignores values of x<0.)
-                        # The sigmoid: (1-(25(x-1))/(1+abs(25(x-1))))/4
-                        # ranges between 0.5 and 0 with a drop around x=1,
-                        # which makes it great for giving a boost to distances < 1Kls.
-                        #
-                        # The sigmoid: (-1-(50(x-4))/(1+abs(50(x-4))))/4
-                        # ranges between 0 and -0.5 with a drop around x=4,
-                        # making it great for penalizing distances > 4Kls.
-                        #
-                        # The curve: (-1+1/(x+1)^((x+1)/4))/2
-                        # ranges between 0 and -0.5 in a smooth arc,
-                        # which will be used for making distances
-                        # closer to 4Kls get a slightly higher penalty
-                        # then distances closer to 1Kls.
-                        #
-                        # Adding the three together creates a doubly-kinked curve
-                        # that ranges from ~0.5 to -1.0, with drops around x=1 and x=4,
-                        # which closely matches ksfone's intention without going into
-                        # negative numbers and causing problems when we add it to
-                        # the multiplier variable. ( 1 + -1 = 0 )
-                        #
-                        # You can see a graph of the formula here:
-                        # https://goo.gl/sn1PqQ
-                        # NOTE: The black curve is at a penalty of 0%,
-                        # the red curve at a penalty of 100%, with intermediates at
-                        # 25%, 50%, and 75%.
-                        # The other colored lines show the penalty curves individually
-                        # and the teal composite of all three.
-                        
-                        def sigmoid(x):
-                            return x / (1 + abs(x))
-                        
-                        boost = (1 - sigmoid(25 * (cruiseKls - 1))) / 4
-                        drop = (-1 - sigmoid(50 * (cruiseKls - 4))) / 4
-                        try:
-                            penalty = (-1 + 1 / (cruiseKls + 1) ** ((cruiseKls + 1) / 4)) / 2
-                        except OverflowError:
-                            penalty = -0.5
-                        
-                        multiplier += (penalty + boost + drop) * lsPenalty
-                    
-                    score *= multiplier
-                    
-                    dstID = dstStation.ID
-                    try:
-                        # See if there is already a candidate for this destination
-                        btd = bestToDest[dstID]
-                    except KeyError:
-                        # No existing candidate, we win by default
-                        pass
-                    else:
-                        bestRoute = btd[1]
-                        bestScore = btd[5]
-                        # Check if it is a better option than we just produced
-                        bestTradeScore = bestRoute.score + bestScore
-                        newTradeScore = route.score + score
-                        if bestTradeScore > newTradeScore:
-                            continue
-                        if bestTradeScore == newTradeScore:
-                            bestLy = btd[4]
-                            if bestLy <= dest.distLy:
-                                continue
-                    
-                    bestToDest[dstID] = (
-                        dstStation, route, trade, dest.via, dest.distLy, score
+                def annotate(dest):
+                    tdenv.DEBUG1(
+                        "destSys {}, destStn {}, jumps {}, distLy {}",
+                        dest.system.dbname,
+                        dest.station.dbname,
+                        "->".join(jump.text() for jump in dest.via),
+                        dest.distLy
                     )
+                    return True
+                
+                stations = (d for d in stations if annotate(d))
+            
+            for dest in stations:
+                dstStation = dest.station
+                
+                connections += 1
+                items = self.getTrades(srcStation, dstStation, srcSelling)
+                if not items:
+                    continue
+                trade = fitFunction(items, startCr, capacity, maxUnits)
+                
+                multiplier = 1.0
+                # Calculate total K-lightseconds supercruise time.
+                # This will amortize for the start/end stations
+                dstSys = dest.system
+                if goalSystem and dstSys is not goalSystem:
+                    dstGoalDist = goalDistTo(dstSys)
+                    # Biggest reward for shortening distance to goal
+                    score = 5000 * origGoalDist / dstGoalDist
+                    # bias towards bigger reductions
+                    score += 50 * srcGoalDist / dstGoalDist
+                    # discourage moving back towards origin
+                    if dstSys is not origSystem:
+                        score += 10 * (origDistTo(dstSys) - srcOrigDist)
+                    # Gain per unit pays a small part
+                    score += (trade.gainCr / trade.units) / 25
+                else:
+                    score = trade.gainCr
+                if lsPenalty:
+                    # [kfsone] Only want 1dp
+                    
+                    cruiseKls = int(dstStation.lsFromStar / 100) / 10
+                    # Produce a curve that favors distances under 1kls
+                    # positively, starts to penalize distances over 1k,
+                    # and after 4kls starts to penalize aggressively
+                    # http://goo.gl/Otj2XP
+                    
+                    # [eyeonus] As aadler pointed out, this goes into negative
+                    # numbers, which causes problems.
+                    # penalty = ((cruiseKls ** 2) - cruiseKls) / 3
+                    # penalty *= lsPenalty
+                    # multiplier *= (1 - penalty)
+                    
+                    # [eyeonus]:
+                    # (Keep in mind all this ignores values of x<0.)
+                    # The sigmoid: (1-(25(x-1))/(1+abs(25(x-1))))/4
+                    # ranges between 0.5 and 0 with a drop around x=1,
+                    # which makes it great for giving a boost to distances < 1Kls.
+                    #
+                    # The sigmoid: (-1-(50(x-4))/(1+abs(50(x-4))))/4
+                    # ranges between 0 and -0.5 with a drop around x=4,
+                    # making it great for penalizing distances > 4Kls.
+                    #
+                    # The curve: (-1+1/(x+1)^((x+1)/4))/2
+                    # ranges between 0 and -0.5 in a smooth arc,
+                    # which will be used for making distances
+                    # closer to 4Kls get a slightly higher penalty
+                    # then distances closer to 1Kls.
+                    #
+                    # Adding the three together creates a doubly-kinked curve
+                    # that ranges from ~0.5 to -1.0, with drops around x=1 and x=4,
+                    # which closely matches ksfone's intention without going into
+                    # negative numbers and causing problems when we add it to
+                    # the multiplier variable. ( 1 + -1 = 0 )
+                    #
+                    # You can see a graph of the formula here:
+                    # https://goo.gl/sn1PqQ
+                    # NOTE: The black curve is at a penalty of 0%,
+                    # the red curve at a penalty of 100%, with intermediates at
+                    # 25%, 50%, and 75%.
+                    # The other colored lines show the penalty curves individually
+                    # and the teal composite of all three.
+                    
+                    def sigmoid(x):
+                        return x / (1 + abs(x))
+                    
+                    boost = (1 - sigmoid(25 * (cruiseKls - 1))) / 4
+                    drop = (-1 - sigmoid(50 * (cruiseKls - 4))) / 4
+                    try:
+                        penalty = (-1 + 1 / (cruiseKls + 1) ** ((cruiseKls + 1) / 4)) / 2
+                    except OverflowError:
+                        penalty = -0.5
+                    
+                    multiplier += (penalty + boost + drop) * lsPenalty
+                
+                score *= multiplier
+                
+                dstID = dstStation.ID
+                try:
+                    # See if there is already a candidate for this destination
+                    btd = bestToDest[dstID]
+                except KeyError:
+                    # No existing candidate, we win by default
+                    pass
+                else:
+                    bestRoute = btd[1]
+                    bestScore = btd[5]
+                    # Check if it is a better option than we just produced
+                    bestTradeScore = bestRoute.score + bestScore
+                    newTradeScore = route.score + score
+                    if bestTradeScore > newTradeScore:
+                        continue
+                    if bestTradeScore == newTradeScore:
+                        bestLy = btd[4]
+                        if bestLy <= dest.distLy:
+                            continue
+                
+                bestToDest[dstID] = (
+                    dstStation, route, trade, dest.via, dest.distLy, score
+                )
         
         if connections == 0:
-            raise NoHopsError(
-                "No destinations could be reached within the constraints."
-            )
+            return []
         
         result = []
         for (dst, route, trade, jumps, _, score) in bestToDest.values():
             result.append(route.plus(dst, trade, jumps, score))
+            
+        pickledResult = list(map(lambda r: JarredRoute(r), result))
         
-        return result
+        return pickledResult

--- a/tradedangerous/tradecalcchunk.py
+++ b/tradedangerous/tradecalcchunk.py
@@ -1,0 +1,24 @@
+import sys
+from sys import argv
+
+from tradedangerous import tradedb, commands
+from tradedangerous.tradecalc import TradeCalc
+
+this = sys.modules[__name__]
+this.cmdIndex = None
+this.cmdenv = None
+this.local_tdb = None
+this.calc = None
+
+def init_tradecalcchunk():
+    this.cmdIndex = commands.CommandIndex()
+    this.cmdenv = this.cmdIndex.parse(argv)
+    this.local_tdb = tradedb.TradeDB(this.cmdenv, load=True)
+    this.cmdenv.initAndCheckParams(this.local_tdb)
+    this.calc = TradeCalc(this.local_tdb, this.cmdenv)
+    
+def init_calctradechunk_thread(calc):
+    this.calc = calc
+
+def run_route(route, restrictTo=None):
+    return this.calc.getBestHops(route, restrictTo=restrictTo)


### PR DESCRIPTION
Waiting for TD to crunch the numbers does give one some free time with nothing to do, so I took a jab at implementing multiprocessing. This PR shouldn't be considered ready to merge, as it still has a bunch of problems to address, but I thought I'd put this out to solicit feedback and advice. I'm not a Python guy, so please forgive the weird coding style.

TL;DR: I did some work on multiprocessing and it looks like it's working, there's still a bunch of things to do and probably bugs to fix, but this is rather cool, isn't it?

The long version:

## Goal
The goal is to allow the `run` command to process routes with multiple worker processes.

## Restrictions
To make the goal achievable and the result maintainable, the following restrictions were accepted:
1. Use only standard python libraries for multiprocessing
2. Make it work without extensive refactoring the existing code

## Choices
Among the options python stdlib offers for multiprocessing, `concurrent.futures` was chosen as the easiest to work with. All management of worker processes happens under the hood, and the `futures` arrays are easy to work with.

Any data passed to the workers must be pickled, that is, transformed to a form suitable for passing between the processes. In TD, the most important unpicklable thing is `TradeDB`, due to circular references and unpicklable `Sqlite3` connection. However, `TradeDB` can easily be loaded by each worker independently, so this is not a problem. In the end, `TradeCalc.getBestHops` loop was chosen as the interface between the workers and the main process. It accepts and returns `route` objects, as well as accepting `restrictTo` array of places, both of which can easily be prepared for pickling (which is handled by `JarredRoute` and `JarredPlace` classes).

The function that is called by the worker processes must be a top-level function, apparently, so I defined it separately from any classes. Calling anything on `TradeCalc` will require pickling `self`, which includes `TradeDB`, and I didn't want to mess with `TradeCalc` too much. Initialisation functions are defined as top-level functions as well. I have no idea if this can be made prettier, but, well, for the moment it just sits in the `tradecalcchunk.py` file.

There can only be one progress bar at a time, so I moved the progress bar handling to the `run_cmd.py` file. One more thing that got moved, or rather copied, to the outside of `getBestHops` loop is destination deduplication part. As workers aren't aware of each other, the responsibility to choose the best route to destination must be taken to the master process. I didn't remove this process from `getBestHops` because, well, it doesn't really hurt having it in two places, and having less data to pass between processes is probably good.

`cmdenv` got the option parsing pass separated from the `run` function, as I needed workers to construct their `cmdenv` independently. Thankfully, `concurrent.futures` passes `argv` to the worker processes, so that was easy.

Worker pool spawns new workers with `spawn` method. This method works on all of Windows, MacOS and Linux. `fork` might be better on Linux, but that would require supporting two implementations, and my guess is that you can't really fork with sqlite3 connection present without messing things up, so `TradeDB` cannot be loaded before forking anyway. Eh, it can be added later if anyone is interested.

The choice of one chunk to consist of 100 routes is rather arbitrary. Based on my limited testing 1 seemed to make the workers idle too often, and even 10 had this problem, albeit to a lesser degree.

`NoHopsError` got eliminated, because, well, I didn't want to figure out how to pass exceptions from the workers back to the main thread, and they will probably cause futures to become failed which would require separate processing... Returning empty array works just as well.

## Results
I used this version for a few days, and did some comparison tests with the current version, published to pip. Results are identical, so at least with the options I typically use (`avoid`, `capacity`, `ly-per`, `pad-size`, `jumps-per`, `hops`, `insurance`, `progress`) it seems to work correctly. You may also note the commented out lines, where process worker pool is replaced with thread worker pool. I used those for testing, to see if maybe threads are enough, but it looked like separate processes work better after all. The below are results for testing this on a random run, which takes about 9 minutes (534 seconds) to run on the current version. This was a 2-hop route, with the second hop having 1727 origins to process, and 20 ly * 3 jumps range.

| Workers | Processing time |
| --- | --- |
| (current version) | 534s |
| --- | --- |
| 1 thread | 259s |
| 2 threads | 292s |
| 4 threads | 299s |
| 6 threads | 299s |
| --- | --- |
| 1 process | 317s |
| 2 processes | 257s |
| 4 processes | 226s |
| 6 processes | 220s |

One thing that surprised me here is the fact that having one worker process (besides the master) seems to cut the processing time roughly in half. I have no idea whatsoever why this happens. Otherwise, the results are pretty much what you expect, more threads just makes them compete for the GIL, while more processes do improve time with diminishing results. I'm not sure what's the reason for diminishing results, maybe memory bandwidth becomes the bottleneck. Well, you can't run a lot of workers anyway, unless you have a lot of RAM, as each of them loads their own copy of `TradeDB` and takes about 3GB as a result of that.

If `TradeDB` wasn't loaded to memory in the whole and workers made queries to sqlite instead, the thread option might be more viable, but, well, I'm not ready to refactor the whole application to that extent.

## Problems
This implementation as it stands isn't without problems. For all of these I have absolutely no idea where to start to tackle them, so any input would be appreciated.
- Perhaps the most important for everyday use, interrupting the processing with Ctrl+C (on my Windows machine) interrupts workers, but the master process seems just to hang, requiring to kill it separately
- Existing `tox` tests don't seem to like the worker pool
- It's probably a good idea to add a separate option or something to invoke multiprocessing, and keep the current single-process implementation too for fallback, memory-strapped machines etc. Not sure what's the best course to proceed is, or even if that's necessary
- There's probably a bunch of other problems I just haven't encountered

## Conclusion
Well, this is in early stages, but what do you guys think about this? I think that this can be brought to a decent state with some effort, but I'm interested to hear what everyone, and especially eyeonus, thinks. If this is a dead end for some reason, well, there's no point is wasting the effort, is there?

In any case, thanks for reading this monster of a post.