### PR TITLE
Including Station ID in TradeDangerous.prices file to avoid duplicate stations bug in #206

### DIFF
--- a/tradedangerous/prices.py
+++ b/tradedangerous/prices.py
@@ -180,7 +180,7 @@ def dumpPrices(
         item, catID, category = items[itemID]
         if stnID != lastStn:
             file.write(output)
-            output = "\n\n@ {}/{}\n".format(system.upper(), station)
+            output = "\n\n@ {}/{}:{}\n".format(system.upper(), station, stnID)
             lastStn = stnID
             lastCat = None
         

--- a/tradedangerous/tradedb.py
+++ b/tradedangerous/tradedb.py
@@ -1461,19 +1461,18 @@ class TradeDB:
             return name
         
         slashPos = name.find('/')
-        colonPos = name.find(':')
         if slashPos < 0:
             slashPos = name.find('\\')
         nameOff = 1 if name.startswith('@') else 0
         if slashPos > nameOff:
             # Slash indicates it's, e.g., AULIN/ENTERPRISE
             sysName = name[nameOff:slashPos].upper()
-            stnName = name[slashPos+1:colonPos]
+            stnName = name[slashPos+1:]
         elif slashPos == nameOff:
-            sysName, stnName = None, name[nameOff+1:colonPos]
+            sysName, stnName = None, name[nameOff+1:]
         elif nameOff:
             # It's explicitly a station
-            sysName, stnName = name[nameOff:colonPos].upper(), None
+            sysName, stnName = name[nameOff:].upper(), None
         else:
             # It could be either, use the name for both.
             stnName = name[nameOff:]

--- a/tradedangerous/tradedb.py
+++ b/tradedangerous/tradedb.py
@@ -1461,18 +1461,19 @@ class TradeDB:
             return name
         
         slashPos = name.find('/')
+        colonPos = name.find(':')
         if slashPos < 0:
             slashPos = name.find('\\')
         nameOff = 1 if name.startswith('@') else 0
         if slashPos > nameOff:
             # Slash indicates it's, e.g., AULIN/ENTERPRISE
             sysName = name[nameOff:slashPos].upper()
-            stnName = name[slashPos+1:]
+            stnName = name[slashPos+1:colonPos]
         elif slashPos == nameOff:
-            sysName, stnName = None, name[nameOff+1:]
+            sysName, stnName = None, name[nameOff+1:colonPos]
         elif nameOff:
             # It's explicitly a station
-            sysName, stnName = name[nameOff:].upper(), None
+            sysName, stnName = name[nameOff:colonPos].upper(), None
         else:
             # It could be either, use the name for both.
             stnName = name[nameOff:]


### PR DESCRIPTION
I attempted to use this utility and found I was getting the error listed in #206 and thought I'd take a stab at rectifying it. I admit that I don't have a complete understanding of how your code works at this point but my testing with this seems to show that I can import data via the EDDBLink plugin and then subsequently update it. Searches seem to return correctly both on initial import and an update run and it doesn't appear to have errors with this change.

I am a very new user to this tool and so am unfamiliar with what all ways this could possibly break by incorporating this change, so I defer to others in case I have missed something and this is not an effective change to address this problem. 

I thought to maybe pursue modifying the code to just query the SQL database but that seemed far more involved and would break compatibility I thought with .prices files which I didn't want to do. Unless imports of those are a separate function that wouldn't be impacted in that case?

Either way, let me know what you think about this change.