### PR TITLE
Shorten startup times with data persistence, defer types to database

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,7 @@
+import gc
 import pytest
+import typing
+
 from .helpers import tdenv, touch
 from tradedangerous.tradedb import TradeDB
 
@@ -8,11 +11,14 @@ from tradedangerous.tradedb import TradeDB
 #     copy_fixtures(tdenv.dataDir)
 
 @pytest.fixture(scope="module")
-def tdb() -> TradeDB:
-    tdb = TradeDB()
-    yield tdb
+def tdb() -> typing.Generator[TradeDB, None, None]:
+    instance = TradeDB()
+    yield instance
     # closing tdb when done with it
-    tdb.close()
+    instance.close(final=True)
+    del instance
+    # Make sure we aren't holding on to any handles
+    gc.collect()
 
 
 @pytest.fixture(scope="module")

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,75 +1,41 @@
-import sys
-import os
-import re
-from io import StringIO
 from pathlib import Path
 from contextlib import contextmanager
+import gc
+import os
+import re
+import shutil
+import sys
+import typing
 
-from tradedangerous.tradedb import TradeDB
 from tradedangerous import fs, TradeEnv
-
-__all__ = ['tdenv', 'captured_output', 'is_initialized']
 
 _ROOT = os.path.abspath(os.path.dirname(__file__))
 _DEBUG = 5
 tdenv = TradeEnv(debug=_DEBUG)
 
 @contextmanager
-def captured_output():
-    new_out, new_err = StringIO(), StringIO()
-    old_out, old_err = sys.stdout, sys.stderr
-    try:
-        sys.stdout, sys.stderr = new_out, new_err
-        yield sys.stdout, sys.stderr
-    finally:
-        sys.stdout, sys.stderr = old_out, old_err
-
-@contextmanager
-def replace_stdin(target):
-    orig = sys.stdin
+def replace_stdin(target: typing.TextIO):  
+    orig: typing.TextIO = sys.stdin
     sys.stdin = target
     yield
     sys.stdin = orig
 
 
-def tdfactory():
-    """Generates a usable environment with debug
-    Returns
-    -------
-    [TradeEnv, TradeDB]
-        list with instances of TradeEnv and TradeDB
-    """
-    return [TradeDB(tdenv=tdenv, load=True, debug=_DEBUG), tdenv]
+def empty_path(p: Path) -> None:
+    """Deletes a directory tree including files"""
+    # The way we wind down TradeDB and SQLAlchemy may sometimes
+    # result in a lingering reference to the database that is waiting
+    # to be garbage collected. Force one here.
+    gc.collect()  # Ensure we're not holding onto any files
 
-
-def file_exists(filename):
-    return Path(filename).is_file()
-
-def is_initialized():
-    return Path(tdenv.dataDir, 'TradeDangerous.db').is_file()
-
-def empty_path(p):
-    """Deletes a directory tree including files
-    """
     if p.exists() and p.is_dir():
-        # print("cleaning up", p)
-        for entry in p.glob('*'):
-            if entry.is_file():
-                # print("removing file", entry)
-                entry.unlink()
-            elif entry.is_dir() and entry != p:
-                empty_path(entry)
-        # print("removing directory", entry)
-        p.rmdir()
+        shutil.rmtree(p)
     elif p.is_file():
-        # print("removing file p", entry)
         p.unlink()
 
 
-def remove_fixtures(toDir=None):
-    if not toDir:
-        toDir = tdenv.dataDir
-    toPath = Path(toDir)
+def remove_fixtures(toDir: str | Path | None = None) -> None:
+    toPath = Path(toDir or tdenv.dataDir)
     empty_path(toPath)
 
 
@@ -88,7 +54,7 @@ def copy_fixtures(toDir=None):
     print("copy fixtures done")
 
 
-def touch(*args):
+def touch(*args: str | Path) -> Path:
     filename = Path(*args)
     return fs.touch(filename)
 

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -84,7 +84,6 @@ def copy_fixtures(toDir=None):
     
     fs.copyallfiles(tdenv.templateDir, tdenv.dataDir)
     fs.copyallfiles(Path(_ROOT, 'fixtures'), tdenv.dataDir)
-    fs.ensureflag(Path(tdenv.dataDir, '.tddata'))
     touch(Path(tdenv.dataDir, 'TradeDangerous.db'))
     print("copy fixtures done")
 

--- a/tests/test_fs.py
+++ b/tests/test_fs.py
@@ -25,19 +25,6 @@ class TestFS:
         fs.copy(src, dst)
         assert dst.exists() and dst.is_file()
     
-    def test_ensureflag(self, tdenv):
-        self.result = False
-        flagfile = fs.pathify(tdenv.tmpDir, 'flagtest')
-        if flagfile.exists():
-            flagfile.unlink()
-        
-        def action():
-            self.result = True
-        
-        flag = fs.ensureflag(flagfile, action)
-        assert self.result is True
-        assert flag is not None
-    
     def test_copyallfiles(self, tdenv):
         setup_module()
         fs.copyallfiles(tdenv.templateDir, tdenv.tmpDir)

--- a/tox.ini
+++ b/tox.ini
@@ -31,6 +31,7 @@ exclude =
     .pytest_cache,
     .tox,
     venv,
+    .venv,
     build,
     dist,
     data,
@@ -158,9 +159,8 @@ markers =
 
 [gh-actions]
 python =
-    3.7: py37
-    3.8: py38
-    3.9: py39
     3.10: py310
     3.11: py311
     3.12: py312
+    3.13: py313
+

--- a/tradedangerous/cache.py
+++ b/tradedangerous/cache.py
@@ -29,20 +29,16 @@ import typing
 
 
 from functools import partial as partial_fn
-from sqlalchemy import func, Integer, Float, DateTime, tuple_
-from sqlalchemy import inspect as sa_inspect
+from sqlalchemy import func, tuple_
 from sqlalchemy.orm import Session
-from sqlalchemy.types import DateTime as SA_DateTime
-from tradedangerous.db import make_engine_from_config, get_session_factory
 from tradedangerous.db import orm_models as SA
 from tradedangerous.db import lifecycle
-from tradedangerous.db.utils import parse_ts, get_import_batch_size
+from tradedangerous.db.utils import parse_ts
 
 from .fs import file_line_count
 from .tradeexcept import TradeException
 from tradedangerous.misc.progress import Progress, CountingBar
 from . import corrections, utils
-from . import prices
 
 
 
@@ -50,6 +46,7 @@ from . import prices
 if typing.TYPE_CHECKING:
     from typing import Any, Callable, Optional, TextIO
     
+    from .tradedb import TradeDB
     from .tradeenv import TradeEnv
 
 
@@ -128,7 +125,7 @@ class BuildCacheBaseException(TradeException):
         error       Description of the error
     """
     
-    def __init__(self, fromFile: Path, lineNo: int, error: str = None) -> None:
+    def __init__(self, fromFile: Path, lineNo: int, error: str | None = None) -> None:
         self.fileName = fromFile.name
         self.lineNo = lineNo
         self.category = "ERROR"
@@ -1248,7 +1245,7 @@ def processImportFile(
 
 
 
-def buildCache(tdb, tdenv):
+def buildCache(tdb: TradeDB, tdenv: TradeEnv):
     """
     Rebuilds the database from source files.
     
@@ -1340,7 +1337,7 @@ def buildCache(tdb, tdenv):
 ######################################################################
 
 
-def regeneratePricesFile(tdb, tdenv):
+def regeneratePricesFile(tdb: TradeDB, tdenv: TradeEnv) -> None:
     return
     # """
     # Regenerate the .prices file from the current DB contents.

--- a/tradedangerous/cache.py
+++ b/tradedangerous/cache.py
@@ -22,11 +22,9 @@
 from __future__ import annotations
 
 from pathlib import Path
-from datetime import datetime, date
 import csv
 import os
 import re
-import sys
 import typing
 
 
@@ -50,7 +48,7 @@ from . import prices
 
 # For mypy/pylint type checking
 if typing.TYPE_CHECKING:
-    from typing import Any, Callable, Optional, TextIO  # noqa
+    from typing import Any, Callable, Optional, TextIO
     
     from .tradeenv import TradeEnv
 
@@ -728,7 +726,7 @@ def processPricesFile(
     tdenv: "TradeEnv",
     session: Session,
     pricesPath: Path,
-    pricesFh: Optional[typing.TextIO] = None,
+    pricesFh: Optional[TextIO] = None,
     defaultZero: bool = False,
 ) -> None:
     """

--- a/tradedangerous/cli.py
+++ b/tradedangerous/cli.py
@@ -121,7 +121,7 @@ def trade(argv):
         results = cmdenv.run(tdb)
     finally:
         # always close tdb
-        tdb.close()
+        tdb.close(final=True)
     
     if results:
         results.render()

--- a/tradedangerous/commands/import_cmd.py
+++ b/tradedangerous/commands/import_cmd.py
@@ -166,6 +166,7 @@ def run(results, cmdenv: TradeEnv, tdb: TradeDB):
     # Refresh/close any cached handles before file ops (kept from original)
     tdb.reloadCache()
     tdb.close()
+    tdb.removePerist()
     
     # Treat a bare http(s) string in 'filename' as a URL
     if cmdenv.filename:

--- a/tradedangerous/commands/import_cmd.py
+++ b/tradedangerous/commands/import_cmd.py
@@ -9,6 +9,7 @@
 # This module remains available for compatibility with old “.prices” files,
 # but the format is being phased out and may be removed in a future release.
 
+from __future__ import annotations
 
 from .exceptions import CommandLineError
 from .parsing import ParseArgument, MutuallyExclusiveGroup
@@ -18,6 +19,7 @@ from pathlib import Path
 from .. import cache, plugins, transfers
 import re
 import sys
+import typing
 
 try:
     import tkinter
@@ -25,6 +27,11 @@ try:
     hasTkInter = True
 except ImportError:
     hasTkInter = False
+    
+if typing.TYPE_CHECKING:
+    from ..tradedb import TradeDB
+    from ..tradeenv import TradeEnv
+
 
 ######################################################################
 # Parser config
@@ -115,7 +122,7 @@ switches = [
 # Perform query and populate result set
 
 
-def run(results, cmdenv, tdb):
+def run(results, cmdenv: TradeEnv, tdb: TradeDB):
     """
     Dispatch import work:
       • If a plugin (-P) is specified: load it and run it (no deprecation banner).

--- a/tradedangerous/commands/import_cmd.py
+++ b/tradedangerous/commands/import_cmd.py
@@ -27,7 +27,7 @@ try:
     hasTkInter = True
 except ImportError:
     hasTkInter = False
-    
+
 if typing.TYPE_CHECKING:
     from ..tradedb import TradeDB
     from ..tradeenv import TradeEnv

--- a/tradedangerous/commands/rares_cmd.py
+++ b/tradedangerous/commands/rares_cmd.py
@@ -5,7 +5,9 @@ from .parsing import (
     PlanetaryArgument, FleetCarrierArgument, OdysseyArgument,
 )
 from ..formatting import RowFormat, max_len
-from ..tradedb import TradeDB
+from ..tradedb import TradeDB, select, SA_Category, SA_RareItem, SA_Station
+
+import time
 
 
 ######################################################################
@@ -104,13 +106,6 @@ def run(results, cmdenv, tdb):
     # How far we're want to cast our net.
     maxLy = float(cmdenv.maxLyPer or 0.0)
     
-    if cmdenv.illegal:
-        wantIllegality = 'Y'
-    elif cmdenv.legal:
-        wantIllegality = 'N'
-    else:
-        wantIllegality = 'YN?'
-    
     awaySystems = set()
     if cmdenv.away or cmdenv.awayFrom:
         if not cmdenv.away or not cmdenv.awayFrom:
@@ -129,10 +124,29 @@ def run(results, cmdenv, tdb):
     distCheckFn = start.distanceTo
     
     # Look through the rares list.
-    for rare in tdb.rareItemByID.values():
-        if rare.illegal not in wantIllegality:
-            continue
-        stn = rare.station
+    stmt = select(
+        SA_RareItem.rare_id,
+        SA_RareItem.station_id,
+        SA_RareItem.name,
+        SA_RareItem.cost,
+        SA_RareItem.max_allocation,
+        SA_RareItem.illegal,
+        SA_RareItem.suppressed,
+        SA_Category.name
+    ).join(SA_Category)
+    if cmdenv.illegal or cmdenv.legal:
+       stmt = stmt.where(SA_RareItem.illegal == ('Y' if cmdenv.legal else 'N'))
+    if noPlanet:
+        stmt = stmt.join(SA_Station).where(SA_Station.planetary != 'Y')
+    
+    awaySystems = set()
+
+    started = time.time()
+    with tdb.Session() as session:
+        rows = session.execute(stmt).all()
+
+    for rare in rows:
+        stn = tdb.stationByID[rare.station_id]
         if padSize and not stn.checkPadSize(padSize):
             continue
         if planetary and not stn.checkPlanetary(planetary):
@@ -140,8 +154,6 @@ def run(results, cmdenv, tdb):
         if fleet and not stn.checkFleet(fleet):
             continue
         if odyssey and not stn.checkOdyssey(odyssey):
-            continue
-        if noPlanet and stn.planetary != 'N':
             continue
         
         rareSys = stn.system
@@ -159,6 +171,8 @@ def run(results, cmdenv, tdb):
         row.station = stn            # <-- IMPORTANT: used by render()
         row.dist = dist
         results.rows.append(row)
+        
+    cmdenv.DEBUG0("Found {:n} rares in {:.3f}s", len(results.rows), time.time() - started)
     
     # Was anything matched?
     if not results.rows:
@@ -166,7 +180,7 @@ def run(results, cmdenv, tdb):
         return None
     
     # Sort safely even if rare.costCr is None (treat None as 0)
-    price_key = lambda row: (row.rare.costCr or 0)
+    price_key = lambda row: (row.rare.cost or 0)
     
     if cmdenv.sortByPrice:
         results.rows.sort(key=lambda row: row.dist)
@@ -204,24 +218,24 @@ def render(results, cmdenv, tdb):
     # Helpers to coalesce possibly-missing attributes
     def _cost(row):
         try:
-            v = row.rare.costCr
+            v = row.rare.cost
             return int(v) if v is not None else 0
         except Exception:
             return 0
     
     def _rare_name(row):
         try:
-            n = row.rare.name()
+            n = row.rare.name
             return n or "?"
         except Exception:
             return "?"
     
     def _alloc(row):
-        val = getattr(row.rare, "allocation", None)
+        val = row.rare.max_allocation
         return str(val) if val not in (None, "") else "?"
     
     def _rare_illegal(row):
-        val = getattr(row.rare, "illegal", None)
+        val = row.rare.illegal
         return val if val in ("Y", "N", "?") else "?"
     
     def _stn_ls(row):

--- a/tradedangerous/db/utils.py
+++ b/tradedangerous/db/utils.py
@@ -16,11 +16,11 @@ from typing import Optional, Iterable, Mapping, Sequence, Literal, Callable, Dic
 import re
 
 from sqlalchemy import Table, text, func, and_, bindparam
-from sqlalchemy.engine import Connection
 from sqlalchemy.orm import Session
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlalchemy.dialects.mysql import insert as mysql_insert
 from sqlalchemy.sql.elements import ClauseElement
+
 
 # --------------------------------------------------------
 # eddblink helpers
@@ -31,7 +31,7 @@ def begin_bulk_mode(
     *,
     profile: str = "default",
     phase: Literal["rebuild", "incremental"] = "incremental",
-) -> Dict[str, Any]:
+) -> dict[str, Any]:
     """
     Apply connection-local settings to speed up bulk operations.
     Returns an opaque token for symmetry with end_bulk_mode (currently a no-op).
@@ -44,7 +44,7 @@ def begin_bulk_mode(
         to the pool or closed.
       * This is generic and safe for any plugin invoking long-running bulk writes.
     """
-    token: Dict[str, Any] = {"dialect": None, "profile": profile, "phase": phase}
+    token: dict[str, Any] = {"dialect": None, "profile": profile, "phase": phase}
 
     try:
         dialect = session.get_bind().dialect.name.lower()
@@ -526,7 +526,7 @@ def get_foreign_keys(session, table_name: str) -> list[dict]:
 # Timestamp Helpers
 # -----------------------------------------------------------------------------
 
-def age_in_days(session, column: ClauseElement) -> ClauseElement:
+def age_in_days(session: Session, column: ClauseElement) -> ClauseElement:
     """
     Return a dialect-safe SQLAlchemy expression that yields the age of `column`
     (a DATETIME/TIMESTAMP) in **whole days** relative to the database's current date.

--- a/tradedangerous/fs.py
+++ b/tradedangerous/fs.py
@@ -1,17 +1,28 @@
 """This module should handle filesystem related operations
 """
-from shutil import copy as shcopy
 from os import makedirs, PathLike
 from pathlib import Path
+from shutil import copy as shcopy
+import typing
 
 __all__ = ['copy', 'copyallfiles', 'touch', 'ensurefolder', 'file_line_count']
 
-def pathify(*args):
+Pathlike: typing.TypeAlias = Path | str
+
+
+def pathify(*args: str | Path) -> Path:
+    """ pathify will ensure a Path given input(s) that can be
+        either a single Path/str, or components to form one.
+        e.g.
+            pathify("C:/temp") -> Path("c:/temp")
+            pathify("C":", "temp") -> Path("C:/temp")
+            pathify("C:", Path("temp")) -> Path("C:/temp")
+    """
     if len(args) > 1 or not isinstance(args[0], Path):
         return Path(*args)
     return args[0]
 
-def copy(src, dst):
+def copy(src: PathLike, dst: PathLike) -> Path:
     """
     copy src to dst
     takes string or Path object as input
@@ -23,7 +34,8 @@ def copy(src, dst):
     shcopy(str(srcPath), str(dstPath))
     return dstPath
 
-def copy_if_newer(src, dst):
+
+def copy_if_newer(src: Pathlike, dst: Pathlike) -> Path:
     """
     copy src to dst if src is newer
     takes string or Path object as input
@@ -36,10 +48,10 @@ def copy_if_newer(src, dst):
     if dstPath.exists() and dstPath.stat().st_mtime >= srcPath.stat().st_mtime:
         return srcPath
     
-    shcopy(str(srcPath), str(dstPath))
+    shcopy(srcPath, dstPath)    # kfs: python 3.10 don't need us to strify these
     return dstPath
 
-def copyallfiles(srcdir, dstdir):
+def copyallfiles(srcdir: Pathlike, dstdir: Pathlike) -> None:
     """
     Copies all files in srcdir to dstdir
     """
@@ -50,7 +62,7 @@ def copyallfiles(srcdir, dstdir):
         if p.is_file():
             copy(p, dstPath / p.name)
 
-def touch(filename):
+def touch(filename: Pathlike) -> Path:
     """
     Creates file if it doesn't exist.
     Always modifies utime.
@@ -60,7 +72,7 @@ def touch(filename):
     path.touch(exist_ok=True)
     return path
 
-def ensureflag(flagfile, action=None):
+def ensureflag(flagfile: Pathlike, action: callable) -> None:
     """Checks if flagfile exist and IF NOT the action function
     will be executed. The flagfile will be 'touched' at the end
     
@@ -80,7 +92,7 @@ def ensureflag(flagfile, action=None):
         action()
     return touch(flagPath)
 
-def ensurefolder(folder):
+def ensurefolder(folder: Pathlike) -> Path:
     """Creates the folder if it doesn't exist
     
     Parameters
@@ -101,7 +113,7 @@ def ensurefolder(folder):
     return folderPath.resolve()
 
 
-def file_line_count(from_file: PathLike, buf_size: int = 128 * 1024, *, missing_ok: bool = False) -> int:
+def file_line_count(from_file: Pathlike, buf_size: int = 128 * 1024, *, missing_ok: bool = False) -> int:
     """ counts the number of newline characters in a given file. """
     if not isinstance(from_file, Path):
         from_file = Path(from_file)

--- a/tradedangerous/fs.py
+++ b/tradedangerous/fs.py
@@ -72,26 +72,6 @@ def touch(filename: Pathlike) -> Path:
     path.touch(exist_ok=True)
     return path
 
-def ensureflag(flagfile: Pathlike, action: callable) -> None:
-    """Checks if flagfile exist and IF NOT the action function
-    will be executed. The flagfile will be 'touched' at the end
-    
-    Parameters
-    ----------
-    flagfile : string
-        path to the file used as flag
-    action : callable
-        this will be called if the flagfile doesn't exist
-    
-    Returns
-    -------
-    Path(flagfile)
-    """
-    flagPath = pathify(flagfile)
-    if not flagPath.exists() and callable(action):
-        action()
-    return touch(flagPath)
-
 def ensurefolder(folder: Pathlike) -> Path:
     """Creates the folder if it doesn't exist
     

--- a/tradedangerous/plugins/eddblink_plug.py
+++ b/tradedangerous/plugins/eddblink_plug.py
@@ -456,6 +456,8 @@ class ImportPlugin(plugins.ImportPluginBase):
             if self.downloadFile(self.commoditiesPath) or self.getOption("force"):
                 self.downloadFile(self.categoriesPath)
                 buildCache = True
+
+        modified = buildCache
         
         # Remake the .db files with the updated info.
         if buildCache:
@@ -465,17 +467,24 @@ class ImportPlugin(plugins.ImportPluginBase):
         
         if self.getOption("purge"):
             self.purgeSystems()
+            modified = True
         
         # Listings import (prices)
         if self.getOption("listings"):
             if self.downloadFile(self.listingsPath) or self.getOption("force"):
                 self.importListings(self.listingsPath)
+                modified = True
             if self.downloadFile(self.liveListingsPath) or self.getOption("force"):
                 self.importListings(self.liveListingsPath)
+                modified = True
         
         # if self.getOption("listings"):
         #     self.tdenv.NOTE("Regenerating .prices file.")
         #     cache.regeneratePricesFile(self.tdb, self.tdenv)
         
         self.tdenv.NOTE("Import completed.")
+
+        if modified:
+            self.tdb.removePersist()
+
         return False

--- a/tradedangerous/tradedb.py
+++ b/tradedangerous/tradedb.py
@@ -131,11 +131,12 @@ if typing.TYPE_CHECKING:
 # Ultimately it just needs to be something that tells us we can't
 # reasonably reconstitute the same data when running this version
 # against that file.
-PERSIST_FORMAT = 1
+PERSIST_FORMAT = 2
 
 # Names for the fields in the persist header.
 PERSIST_FORMAT_FIELD = "fmtv"
 PERSIST_TIMESTAMP_FIELD = "dbts"
+PERSIST_SIZE_FIELD = "dbsz"
 
 
 ######################################################################
@@ -2143,6 +2144,11 @@ class TradeDB:
         if (old_db_timestamp := header.get(PERSIST_TIMESTAMP_FIELD)) != cur_db_timestamp:
             self.tdenv.DEBUG0("persist data is stale by timestamp: cur={}, file={}", cur_db_timestamp, old_db_timestamp)
             return False
+        cur_db_size = self.dbPath.stat().st_size
+        if (old_db_size := header.get(PERSIST_SIZE_FIELD)) != cur_db_size:
+            self.tdenv.DEBUG0("persist data is stale by size: cur={}, file={}", cur_db_size, old_db_size)
+            return False
+        self.tdenv.DEBUG1("persist data not expired by time (cur={}, file={}) or size (cur={}, file={})", cur_db_timestamp, old_db_timestamp, cur_db_size, old_db_size)
         
         data = pickle.load(jar)
         eof_marker = pickle.load(jar)
@@ -2175,15 +2181,17 @@ class TradeDB:
             raise e from e
         
         try:
-            cur_db_timestamp = self.dbPath.stat().st_mtime
+            stat = self.dbPath.stat()
         except FileNotFoundError:
             # Can't persist what we don't have
             self.tdenv.DEBUG0("unable to persist: the db file is dead, Dave")
             return False
+        cur_db_timestamp, cur_db_size = stat.st_mtime, stat.st_size
         
         header = {
             PERSIST_FORMAT_FIELD: PERSIST_FORMAT,
-            PERSIST_TIMESTAMP_FIELD: cur_db_timestamp
+            PERSIST_TIMESTAMP_FIELD: cur_db_timestamp,
+            PERSIST_SIZE_FIELD: cur_db_size,
         }
         data = {
             "system":   (self.systemByID, self.systemByName),

--- a/tradedangerous/tradedb.py
+++ b/tradedangerous/tradedb.py
@@ -54,6 +54,7 @@ from __future__ import annotations
 
 from collections import namedtuple
 from contextlib import closing
+from functools import lru_cache
 from math import sqrt as math_sqrt
 from pathlib import Path
 import heapq
@@ -75,6 +76,7 @@ if typing.TYPE_CHECKING:
 locale.setlocale(locale.LC_ALL, '')
 
 from sqlalchemy import func, select
+from sqlalchemy.exc import NoResultFound
 from sqlalchemy.orm import Session
 from .db import make_engine_from_config, get_session_factory, healthcheck
 from .db.orm_models import (
@@ -646,12 +648,10 @@ class TradeDB:
         # --- Cache attributes (unchanged) ---
         self.avgSelling, self.avgBuying = None, None
         self.tradingStationCount = 0
-        self.addedByID      = None
         self.systemByID     = None
         self.systemByName   = None
         self.stellarGrid    = None
         self.stationByID    = None
-        self.shipByID       = None
         self.categoryByID   = None
         self.itemByID       = None
         self.itemByName     = None
@@ -781,30 +781,20 @@ class TradeDB:
 
     
     ############################################################
-    # Load "added" data.
-    
-    def _loadAdded(self):
-        """
-        Loads the Added table as a simple dictionary.
-        """
-        addedByID = {}
-        with self.Session() as session:
-            for row in session.query(Added.added_id, Added.name):
-                addedByID[row.added_id] = row.name
-        self.addedByID = addedByID
-        self.tdenv.DEBUG1("Loaded {:n} Addeds", len(addedByID))
-    
+    # [deprecated] "added" data.
     
     def lookupAdded(self, name):
-        name = name.lower()
-        for ID, added in self.addedByID.items():
-            if added.lower() == name:
-                return ID
-        raise KeyError(name)
+        stmt = select(SA_Added.added_id).where(SA_Added.name == name)
+        with self.Session() as session:
+            try:
+                return session.execute(stmt).scalar_one()
+            except NoResultFound:
+                raise KeyError(name) from None
     
     ############################################################
     # Star system data.
     
+    # TODO: Defer to SA_System as much as possible
     def systems(self):
         """ Iterate through the list of systems. """
         yield from self.systemByID.values()
@@ -1899,41 +1889,24 @@ class TradeDB:
     ############################################################
     # Ship data.
     
-    def ships(self):
-        """ Iterate through the list of ships. """
-        yield from self.shipByID.values()
-    
-    def _loadShips(self):
-        """
-        Populate the Ship list using SQLAlchemy.
-        CAUTION: Will orphan previously loaded objects.
-        """
-        with self.Session() as session:
-            rows = session.query(
-                SA_Ship.ship_id,
-                SA_Ship.name,
-                SA_Ship.cost,
-            )
-            self.shipByID = {
-                row.ship_id: Ship(row.ship_id, row.name, row.cost, stations=[])
-                for row in rows
-            }
-        
-        self.tdenv.DEBUG1("Loaded {} Ships", len(self.shipByID))
-    
-    
+    @lru_cache
     def lookupShip(self, name):
-        """
-        Look up a ship by name
-        """
-        return TradeDB.listSearch(
-            "Ship", name, self.shipByID.values(),
-            key=lambda ship: ship.dbname
-        )
+        """ Look up a ship by name. """
+        stmt = select(SA_Ship.ship_id, SA_Ship.name, SA_Ship.cost)   \
+                   .where(Ship.name == name)
+        with self.Session() as session:
+            try:
+                row = session.execute(stmt).scalar_one()
+                return Ship(row.ship_id, row.name, row.cost, stations=[])
+            except NoResultFound:
+                raise LookupError(f"Error: '{name}' doesn't match any Ship") from None
     
     ############################################################
     # Item data.
     
+    # TODO: Defer to SA_Category directly; requires migrating
+    # all item references to the SA_Item table too (since then
+    # the database relationship handles inheritance anyway)
     def categories(self):
         """
         Iterate through the list of categories.
@@ -1968,6 +1941,7 @@ class TradeDB:
             key=lambda cat: cat.dbname
         )
     
+    # TODO: Defer to SA_Item directly.
     def items(self):
         """ Iterate through the list of items. """
         yield from self.itemByID.values()
@@ -2092,10 +2066,8 @@ class TradeDB:
 
 
         
-        self._loadAdded()
         self._loadSystems()
         self._loadStations()
-        self._loadShips()
         self._loadCategories()
         self._loadItems()
         

--- a/tradedangerous/tradedb.py
+++ b/tradedangerous/tradedb.py
@@ -13,7 +13,7 @@
 """
 Provides the primary classes used within TradeDangerous:
 
-TradeDB, System, Station, Ship, Item, RareItem and Trade.
+TradeDB, System, Station, Ship, Item, and Trade.
 
 These classes are primarily for describing the database.
 
@@ -656,8 +656,6 @@ class TradeDB:
         self.itemByID       = None
         self.itemByName     = None
         self.itemByFDevID   = None
-        self.rareItemByID   = None
-        self.rareItemByName = None
         
         # --- Engine bootstrap ---
         from .db import make_engine_from_config, get_session_factory
@@ -2071,47 +2069,6 @@ class TradeDB:
     
     
     ############################################################
-    # Rare Items
-    
-    def _loadRareItems(self):
-        """
-        Populate the RareItem list using SQLAlchemy.
-        """
-        rareItemByID, rareItemByName = {}, {}
-        stationByID = self.stationByID
-        
-        with self.Session() as session:
-            rows = session.query(
-                SA_RareItem.rare_id,
-                SA_RareItem.station_id,
-                SA_RareItem.category_id,
-                SA_RareItem.name,
-                SA_RareItem.cost,
-                SA_RareItem.max_allocation,
-                SA_RareItem.illegal,
-                SA_RareItem.suppressed,
-            )
-            for (
-                ID, stnID, catID, name,
-                cost, maxAlloc, illegal, suppressed
-            ) in rows:
-                station  = stationByID[stnID]
-                category = self.categoryByID[catID]
-                rare = RareItem(
-                    ID, station, name,
-                    cost, maxAlloc, illegal, suppressed,
-                    category, f"{category.dbname}/{name}"
-                )
-                rareItemByID[ID] = rare
-                rareItemByName[name] = rare
-        
-        self.rareItemByID  = rareItemByID
-        self.rareItemByName = rareItemByName
-        
-        self.tdenv.DEBUG1("Loaded {:n} RareItems", len(rareItemByID))
-    
-    
-    ############################################################
     # Price data.
     
     def close(self):
@@ -2141,7 +2098,6 @@ class TradeDB:
         self._loadShips()
         self._loadCategories()
         self._loadItems()
-        self._loadRareItems()
         
         # Calculate the maximum distance anyone can jump so we can constrain
         # the maximum "link" between any two stars.

--- a/tradedangerous/tradedb.py
+++ b/tradedangerous/tradedb.py
@@ -1,16 +1,16 @@
-# --------------------------------------------------------------------
-# Copyright (C) Oliver 'kfsone' Smith 2014 <oliver@kfs.org>:
-# Copyright (C) Bernd 'Gazelle' Gollesch 2016, 2017
-# Copyright (C) Stefan 'Tromador' Morrell 2025
-# Copyright (C) Jonathan 'eyeonus' Jones 2018 - 2025
-#
-# You are free to use, redistribute, or even print and eat a copy of
-# this software so long as you include this copyright notice.
-# I guarantee there is at least one bug neither of us knew about.
-# --------------------------------------------------------------------
-# TradeDangerous :: Modules :: Database Module
-
 """
+Copyright (C) Oliver 'kfsone' Smith 2014 <oliver@kfs.org>:
+Copyright (C) Bernd 'Gazelle' Gollesch 2016, 2017
+Copyright (C) Stefan 'Tromador' Morrell 2025
+Copyright (C) Jonathan 'eyeonus' Jones 2018 - 2025
+
+You are free to use, redistribute, or even print and eat a copy of
+this software so long as you include this copyright notice.
+
+I guarantee there is at least one bug neither of us knew about. -- Oliver
+--------------------------------------------------------------------
+TradeDangerous :: Modules :: Database Module
+
 Provides the primary classes used within TradeDangerous:
 
 TradeDB, System, Station, Ship, Item, and Trade.
@@ -71,26 +71,11 @@ from .tradeenv import TradeEnv
 from .tradeexcept import TradeException
 from . import cache, fs
 
-locale.setlocale(locale.LC_ALL, '')
-
 from sqlalchemy import func, select, text
 from sqlalchemy.exc import NoResultFound
-from sqlalchemy.orm import Session
-from .db import make_engine_from_config, get_session_factory
-from .db.lifecycle import ensure_fresh_db
-from .db.orm_models import (
-    # System, Station, Item, Category, Ship,
-    Added,
-    ExportControl,
-    RareItem,
-    ShipVendor,
-    StationItem,
-    StationItemStaging,
-    Upgrade,
-    UpgradeVendor,
-)  # noqa: F401  pylint: disable=unused-import
-from .db.paths import resolve_data_dir
-from .db.utils import age_in_days
+from .db import make_engine_from_config, get_session_factory  # type: ignore
+from .db.lifecycle import ensure_fresh_db  # type: ignore
+from .db.utils import age_in_days  # type: ignore
 
 # --------------------------------------------------------------------
 # SQLAlchemy ORM imports (aliased to avoid clashing with legacy wrappers).
@@ -105,21 +90,24 @@ from .db.utils import age_in_days
 # entirely, and code updated to use ORM models directly.
 # --------------------------------------------------------------------
 
-from .db.orm_models import (
-    Added           as SA_Added,
-    System          as SA_System,
-    Station         as SA_Station,
-    Item            as SA_Item,
-    Category        as SA_Category,
-    StationItem     as SA_StationItem,
-    RareItem        as SA_RareItem,
-    Ship            as SA_Ship,
-    ShipVendor      as SA_ShipVendor,
-    Upgrade         as SA_Upgrade,
-    UpgradeVendor   as SA_UpgradeVendor,
-    ExportControl   as SA_ExportControl,
+from .db.orm_models import (  # noqa: F401  # pylint: disable=unused-import
+    Added              as SA_Added,
+    System             as SA_System,
+    Station            as SA_Station,
+    Item               as SA_Item,
+    Category           as SA_Category,
+    StationItem        as SA_StationItem,
+    RareItem           as SA_RareItem,
+    Ship               as SA_Ship,
+    ShipVendor         as SA_ShipVendor,
+    Upgrade            as SA_Upgrade,
+    UpgradeVendor      as SA_UpgradeVendor,
+    ExportControl      as SA_ExportControl,
     StationItemStaging as SA_StationItemStaging,
 )
+
+
+locale.setlocale(locale.LC_ALL, '')
 
 
 if typing.TYPE_CHECKING:
@@ -2062,12 +2050,15 @@ class TradeDB:
     ############################################################
     # Price data.
     
-    def close(self):
+    def close(self, *, final: bool = False) -> None:
+        if self.Session and final:
+            del self.Session
         if self.engine:
             self.engine.dispose()
+        if final:
+            engine, self.engine = self.engine, None
+            del engine
         # Keep engine + Session references so reloadCache/buildCache can reuse them
-
-
     
     def load(self, maxSystemLinkLy=None):
         """

--- a/tradedangerous/tradedb.py
+++ b/tradedangerous/tradedb.py
@@ -704,7 +704,7 @@ class TradeDB:
             distance between two 3d coordinates. This is an optimization
             for when you need to compare many coordinate pairs but do
             not actually need to retain the distance value.
-
+            
             That is:
                 distance**2 <=> calculateDistance2(x,y,z, u,v,w)
             always returns the same results as
@@ -1288,7 +1288,7 @@ class TradeDB:
                 SA_Station.planetary,
                 SA_Station.type_id,
             )
-
+        
         for (
             ID, systemID, name,
             lsFromStar, market, blackMarket, shipyard,
@@ -2079,7 +2079,7 @@ class TradeDB:
         """
         
         self.tdenv.DEBUG1("Loading data")
-
+        
         # Try and restore the data from the previous load.
         if not self.readPersist():
             started = time.time()
@@ -2088,7 +2088,7 @@ class TradeDB:
             self._loadCategories()
             self._loadItems()
             self.tdenv.DEBUG0("Data load took {:.3f}s", time.time() - started)
-
+            
             started = time.time()
             self.writePersist()
             self.tdenv.DEBUG1("Data persist took {:.3f}s", time.time() - started)
@@ -2097,7 +2097,7 @@ class TradeDB:
         # the maximum "link" between any two stars.
         msll = maxSystemLinkLy or self.tdenv.maxSystemLinkLy or 30
         self.maxSystemLinkLy = msll
-
+    
     def getPersistPath(self) -> Path:
         """ getPersistPath returns the filepath of the file used to store a snapshot
             of a previously constructed TradeDB object.
@@ -2105,7 +2105,7 @@ class TradeDB:
                     so I went with "pj" for 'pickle jar' because it actually
                     contains two pickles, not just one. """
         return Path(self.dataPath, TradeDB.persistFile)
-
+    
     def readPersist(self) -> bool:
         """ readPersist will attempt to reconstitute the members of TradeDB
             that were persisted to disk from a previous session. """
@@ -2127,7 +2127,7 @@ class TradeDB:
             self.removePersist()
             self.tdenv.WARN("If this problem keeps happening, please report an issue")
         return False
-
+    
     def _readPickleFrom(self, jar: typing.BinaryIO) -> bool:
         """ Inner implementation that performs the reading from the pickle. """
         # We pickle a header and then we pickle data.
@@ -2135,7 +2135,7 @@ class TradeDB:
         if (header_fmt := header.get(PERSIST_FORMAT_FIELD)) != PERSIST_FORMAT:
             self.tdenv.DEBUG0("persist format mismatch: cur={}, file={}", PERSIST_FORMAT, header_fmt)
             return False
-
+        
         # Find when the current database was last modified; if the file doesn't exist,
         # the caller will see this as a file-not-found exception voiding the read.
         cur_db_timestamp = self.dbPath.stat().st_mtime
@@ -2143,12 +2143,12 @@ class TradeDB:
         if (old_db_timestamp := header.get(PERSIST_TIMESTAMP_FIELD)) != cur_db_timestamp:
             self.tdenv.DEBUG0("persist data is stale by timestamp: cur={}, file={}", cur_db_timestamp, old_db_timestamp)
             return False
-
+        
         data = pickle.load(jar)
         eof_marker = pickle.load(jar)
         if eof_marker != "fin":
             raise EOFError("missing eof marker in persistence data")
-
+        
         # We have to repopulate some fields rather than pickle them
         self.systemByID, self.systemByName = data["system"]
         self.stationByID, self.tradingStationCount = data["station"]
@@ -2158,7 +2158,7 @@ class TradeDB:
         self.itemByFDevID = {i.fdevID: i for i in data["item"].values()}
         
         return True
-
+    
     def writePersist(self) -> bool:
         """ Attempt to restore a snapshotted previous version of our data
             as long as all the stars align. """
@@ -2173,14 +2173,14 @@ class TradeDB:
             if jarPath.exists():
                 raise TradeException("Unable to remove old persistence data, the file is inaccssible or open by another program")
             raise e from e
-
+        
         try:
             cur_db_timestamp = self.dbPath.stat().st_mtime
         except FileNotFoundError:
             # Can't persist what we don't have
             self.tdenv.DEBUG0("unable to persist: the db file is dead, Dave")
             return False
-
+        
         header = {
             PERSIST_FORMAT_FIELD: PERSIST_FORMAT,
             PERSIST_TIMESTAMP_FIELD: cur_db_timestamp
@@ -2198,10 +2198,10 @@ class TradeDB:
             pickle.dump("fin", jar)  # EOF marker incase user kills process mid-write.
         
         return True
-
+    
     def removePersist(self):
         self.getPersistPath().unlink(missing_ok=True)
-            
+    
     
     ############################################################
     # General purpose static methods.

--- a/tradedangerous/tradedb.py
+++ b/tradedangerous/tradedb.py
@@ -53,13 +53,14 @@ Simplistic use might be:
 from __future__ import annotations
 
 from collections import namedtuple
-from contextlib import closing
 from functools import lru_cache
 from math import sqrt as math_sqrt
 from pathlib import Path
+from typing import NamedTuple
 import heapq
 import itertools
 import locale
+import os
 import re
 import sys
 import typing
@@ -68,21 +69,24 @@ from .tradeenv import TradeEnv
 from .tradeexcept import TradeException
 from . import cache, fs
 
-if typing.TYPE_CHECKING:
-    from typing import Generator
-    from typing import Optional, Union
-
-
 locale.setlocale(locale.LC_ALL, '')
 
-from sqlalchemy import func, select
+from sqlalchemy import func, select, text
 from sqlalchemy.exc import NoResultFound
 from sqlalchemy.orm import Session
 from .db import make_engine_from_config, get_session_factory, healthcheck
 from .db.orm_models import (
-    System, Station, Item, Category, Ship, Upgrade, RareItem,
-    StationItem, ShipVendor, UpgradeVendor, Added, ExportControl, StationItemStaging
-)
+    # System, Station, Item, Category, Ship,
+    Added,
+    ExportControl,
+    RareItem,
+    ShipVendor,
+    StationItem,
+    StationItemStaging,
+    Upgrade,
+    UpgradeVendor,
+)  # noqa: F401  pylint: disable=unused-import
+from .db.paths import resolve_data_dir
 from .db.utils import age_in_days
 
 # --------------------------------------------------------------------
@@ -115,6 +119,10 @@ from .db.orm_models import (
 )
 
 
+if typing.TYPE_CHECKING:
+    from typing import Any, Callable, Generator, Optional
+
+
 ######################################################################
 # Classes
 
@@ -124,12 +132,12 @@ class AmbiguityError(TradeException):
         Attributes:
             lookupType - description of what was being queried,
             searchKey  - the key given to the search routine,
-            anyMatch - list of anyMatch
+            anyMatch   - list of items which were found to match, if any
             key        - retrieve the display string for a candidate
     """
     def __init__(
-            self, lookupType, searchKey, anyMatch, key=lambda item: item
-            ):
+            self, lookupType: str, searchKey: str, anyMatch: list[Any], key: Callable[[Any], str] = lambda item: item
+            ) -> None:
         self.lookupType = lookupType
         self.searchKey = searchKey
         self.anyMatch = anyMatch
@@ -148,6 +156,7 @@ class AmbiguityError(TradeException):
             opportunities += " or " + key(anyMatch[-1])
         return f'{self.lookupType} "{self.searchKey}" could match {opportunities}'
 
+
 class SystemNotStationError(TradeException):
     """
         Raised when a station lookup matched a System but
@@ -159,13 +168,13 @@ class SystemNotStationError(TradeException):
 ######################################################################
 
 
-def make_stellar_grid_key(x: float, y: float, z: float) -> int:
+def make_stellar_grid_key(x: float, y: float, z: float) -> tuple[int, int, int]:
     """
     The Stellar Grid is a map of systems based on their Stellar
     co-ordinates rounded down to 32lys. This makes it much easier
     to find stars within rectangular volumes.
     """
-    return (int(x) >> 5, int(y) >> 5, int(z) >> 5)
+    return int(x) >> 5, int(y) >> 5, int(z) >> 5
 
 
 class System:
@@ -190,12 +199,12 @@ class System:
             self.systems = []
             self.probed_ly = 0.
     
-    def __init__(self, ID, dbname, posX, posY, posZ, addedID) -> None:
+    def __init__(self, ID: int, dbname: str, posX: float, posY: float, posZ: float, addedID: int|None) -> None:
         self.ID = ID
         self.dbname = dbname
         self.posX, self.posY, self.posZ = posX, posY, posZ
         self.addedID = addedID or 0
-        self.stations = ()
+        self.stations: list['Station'] = []
         self._rangeCache = None
     
     @property
@@ -246,15 +255,17 @@ class System:
 
 ######################################################################
 
-class Destination(namedtuple('Destination', [
-        'system', 'station', 'via', 'distLy'
-        ])):
-    pass
+class Destination(NamedTuple):
+    system: 'System'
+    station: 'Station'
+    via: list['System']
+    distLy: float
 
-class DestinationNode(namedtuple('DestinationNode', [
-        'system', 'via', 'distLy'
-        ])):
-    pass
+
+class DestinationNode(NamedTuple):
+    system: 'System'
+    via: list['System']
+    distLy: float
 
 class Station:
     """
@@ -271,12 +282,12 @@ class Station:
     )
     
     def __init__(
-            self, ID, system, dbname,
-            lsFromStar, market, blackMarket, shipyard, maxPadSize,
-            outfitting, rearm, refuel, repair, planetary, fleet, odyssey,
-            itemCount=0, dataAge=None,
+            self, ID: int, system: 'System', dbname: str,
+            lsFromStar: float, market: str, blackMarket: str, shipyard: str, maxPadSize: str,
+            outfitting: str, rearm: str, refuel: str, repair: str, planetary: str, fleet: str, odyssey: str,
+            itemCount: int = 0, dataAge: float | int | None = None,
             ):
-        self.ID, self.system, self.dbname = ID, system, dbname
+        self.ID, self.system, self.dbname = ID, system, dbname  # type: ignore
         self.lsFromStar = int(lsFromStar)
         self.market = market if itemCount == 0 else 'Y'
         self.blackMarket = blackMarket
@@ -291,12 +302,12 @@ class Station:
         self.odyssey = odyssey
         self.itemCount = itemCount
         self.dataAge = dataAge
-        system.stations = system.stations + (self,)
+        system.stations += [self]
     
     def name(self, detail: int = 0) -> str:  # pylint: disable=unused-argument
         return f"{self.system.dbname}/{self.dbname}"
     
-    def checkPadSize(self, maxPadSize):
+    def checkPadSize(self, maxPadSize: str) -> bool:
         """
         Tests if the Station's max pad size matches one of the
         values in 'maxPadSize'.
@@ -324,7 +335,7 @@ class Station:
         """
         return (not maxPadSize or self.maxPadSize in maxPadSize)
     
-    def checkPlanetary(self, planetary):
+    def checkPlanetary(self, planetary: str) -> bool:
         """
         Tests if the Station's planetary matches one of the
         values in 'planetary'.
@@ -352,14 +363,14 @@ class Station:
         """
         return (not planetary or self.planetary in planetary)
     
-    def checkFleet(self, fleet):
+    def checkFleet(self, fleet: str) -> bool:
         """
         Same as checkPlanetary, but for fleet carriers.
         """
         return (not fleet or self.fleet in fleet)
 
 
-    def checkOdyssey(self, odyssey):
+    def checkOdyssey(self, odyssey: str) -> bool:
         """
         Same as checkPlanetary, but for Odyssey.
         """
@@ -412,9 +423,7 @@ class Station:
 ######################################################################
 
 
-class Ship(namedtuple('Ship', (
-        'ID', 'dbname', 'cost', 'stations'
-        ))):
+class Ship(namedtuple('Ship', ('ID', 'dbname', 'cost', 'stations'))):
     """
     Ship description.
     
@@ -425,15 +434,13 @@ class Ship(namedtuple('Ship', (
         stations    -- List of Stations ship is sold at.
     """
     
-    def name(self, detail=0):   # pylint: disable=unused-argument
+    def name(self, _detail: int = 0) -> str:
         return self.dbname
 
 ######################################################################
 
 
-class Category(namedtuple('Category', (
-        'ID', 'dbname', 'items'
-        ))):
+class Category(namedtuple('Category', ('ID', 'dbname', 'items'))):
     """
     Item Category
     
@@ -453,7 +460,7 @@ class Category(namedtuple('Category', (
             Returns the display name for this Category.
     """
     
-    def name(self, detail=0):   # pylint: disable=unused-argument
+    def name(self, _detail: int = 0) -> str:
         return self.dbname.upper()
 
 ######################################################################
@@ -473,7 +480,7 @@ class Item:
     """
     __slots__ = ('ID', 'dbname', 'category', 'fullname', 'avgPrice', 'fdevID')
     
-    def __init__(self, ID, dbname, category, fullname, avgPrice=None, fdevID=None):
+    def __init__(self, ID: int, dbname: str, category: 'Category', fullname: str, avgPrice: int | None = None, fdevID: int | None = None) -> None:
         self.ID = ID
         self.dbname = dbname
         self.category = category
@@ -481,33 +488,9 @@ class Item:
         self.avgPrice = avgPrice
         self.fdevID   = fdevID
     
-    def name(self, detail=0):
+    def name(self, detail: int = 0):
         return self.fullname if detail > 0 else self.dbname
 
-######################################################################
-
-
-class RareItem(namedtuple('RareItem', (
-        'ID', 'station', 'dbname', 'costCr', 'maxAlloc', 'illegal',
-        'suppressed', 'category', 'fullname',
-        ))):
-    """
-    Describes a RareItem from the database.
-    
-    Attributes:
-        ID         -- Database ID,
-        station    -- Which Station this is bought from,
-        dbname     -- The name are presented in the database,
-        costCr     -- Buying price.
-        maxAlloc   -- How many the player can carry at a time,
-        illegal    -- If the item may be considered illegal,
-        suppressed -- The item is suppressed.
-        category   -- Reference to the category.
-        fullname   -- Combined category/dbname.
-    """
-    
-    def name(self, detail=0):
-        return self.fullname if detail > 0 else self.dbname
 
 ######################################################################
 
@@ -523,7 +506,7 @@ class Trade(namedtuple('Trade', (
     Describes what it would cost and how much you would gain
     when selling an item between two specific stations.
     """
-    def name(self, detail=0):
+    def name(self, detail: int = 0) -> str:
         return self.item.name(detail=detail)
 
 ######################################################################
@@ -607,10 +590,10 @@ class TradeDB:
     
     def __init__(
             self,
-            tdenv=None,
-            load=True,
-            debug=None,
-            ):
+            tdenv: TradeEnv = None,
+            load:  bool     = True,
+            debug: int|None = None,
+            ) -> None:
         # --- SQLAlchemy engine/session (replaces sqlite3.Connection) ---
         self.engine = None
         self.Session = None
@@ -658,9 +641,6 @@ class TradeDB:
         self.itemByFDevID   = None
         
         # --- Engine bootstrap ---
-        from .db import make_engine_from_config, get_session_factory
-        from .db.paths import resolve_data_dir
-        import os
         
         # Determine user's real invocation directory, not venv/bin
         user_cwd = Path(os.getenv("PWD", Path.cwd()))
@@ -681,7 +661,7 @@ class TradeDB:
     # Legacy compatibility dataPath shim
     # ------------------------------------------------------------------
     @property
-    def dataDir(self):
+    def dataDir(self) -> Path:
         """
         Legacy alias for self.dataPath (removed in SQLAlchemy refactor).
         Falls back to './data' if configuration not yet loaded.
@@ -697,17 +677,27 @@ class TradeDB:
     
     
     @staticmethod
-    def calculateDistance2(lx, ly, lz, rx, ry, rz):
-        """
-        Returns the distance in ly between two points.
+    def calculateDistance2(lx: float, ly: float, lz: float, rx: float, ry: float, rz: float) -> float:
+        """ calculateDistance2 returns the *square* (^2) of the euclidean
+            distance between two 3d coordinates. This is an optimization
+            for when you need to compare many coordinate pairs but do
+            not actually need to retain the distance value.
+
+            That is:
+                distance**2 <=> calculateDistance2(x,y,z, u,v,w)
+            always returns the same results as
+                distance    <=> calculateDistance (x,y,z, u,v,w)
+            but is cheaper.
         """
         dx, dy, dz = lx - rx, ly - ry, lz - rz
         return (dx * dx) + (dy * dy) + (dz * dz)
     
     @staticmethod
-    def calculateDistance(lx, ly, lz, rx, ry, rz):
+    def calculateDistance(lx: float, ly: float, lz: float, rx: float, ry: float, rz: float) -> float:
         """
-        Returns the distance in ly between two points.
+        calculateDistance returns the euclidean distance in ly between two points.
+        @note When you are testing many pairs without retaining the calculated value
+        beyond the comparison, consider using calculateDistance2 instead.
         """
         dx, dy, dz = lx - rx, ly - ry, lz - rz
         return math_sqrt((dx * dx) + (dy * dy) + (dz * dz))
@@ -727,7 +717,6 @@ class TradeDB:
         """
         Execute a SQL statement via the SQLAlchemy engine and return the result cursor.
         """
-        from sqlalchemy import text
         with self.engine.connect() as conn:
             return conn.execute(text(sql), params)
     
@@ -739,7 +728,7 @@ class TradeDB:
         return result[0] if result else None
     
     
-    def reloadCache(self):
+    def reloadCache(self) -> None:
         """
         Ensure DB is present and minimally populated using the central policy.
         
@@ -775,7 +764,6 @@ class TradeDB:
         except Exception as e:
             self.tdenv.WARN("reloadCache: ensure_fresh_db failed: {}", e)
             self.tdenv.DEBUG0("reloadCache: Falling back to buildCache()")
-            from tradedangerous import cache
             cache.buildCache(self, self.tdenv)
 
 
@@ -795,11 +783,11 @@ class TradeDB:
     # Star system data.
     
     # TODO: Defer to SA_System as much as possible
-    def systems(self):
+    def systems(self) -> Generator['System', Any, None]:
         """ Iterate through the list of systems. """
         yield from self.systemByID.values()
     
-    def _loadSystems(self):
+    def _loadSystems(self) -> None:
         """
         Initial load of the list of systems via SQLAlchemy.
         CAUTION: Will orphan previously loaded objects.
@@ -829,7 +817,7 @@ class TradeDB:
         self.tdenv.DEBUG1("Loaded {:n} Systems", len(systemByID))
     
     
-    def lookupSystem(self, key):
+    def lookupSystem(self, key: str) -> System | None:
         """
         Look up a System object by it's name.
         """
@@ -848,7 +836,7 @@ class TradeDB:
             x, y, z,
             modified='now',
             commit=True,
-            ):
+            ) -> System:
         """
         Add a system to the local cache and memory copy using SQLAlchemy.
         Note: 'added' field has been deprecated and is no longer populated.
@@ -889,7 +877,7 @@ class TradeDB:
             name, x, y, z, added="Local", modified='now',
             force=False,
             commit=True,
-            ):
+            ) -> bool:
         """
         Update an entry for a local system using SQLAlchemy.
         """
@@ -907,7 +895,7 @@ class TradeDB:
         
         with self.Session() as session:
             # Find Added row for added_id
-            added_row = session.query(Added).filter(Added.name == added).first()
+            added_row = session.query(SA_Added).filter(SA_Added.name == added).first()
             if not added_row:
                 raise TradeException(f"Added entry not found: {added}")
             
@@ -978,7 +966,7 @@ class TradeDB:
         del system
     
     
-    def __buildStellarGrid(self):
+    def __buildStellarGrid(self) -> None:
         """
         Divides the galaxy into a fixed-sized grid allowing us to
         aggregate small numbers of stars by locality.
@@ -992,7 +980,7 @@ class TradeDB:
                 grid = stellarGrid[key] = []
             grid.append(system)
     
-    def genStellarGrid(self, system, ly):
+    def genStellarGrid(self, system: 'System', ly: float):
         """
         Yields Systems within a given radius of a specified System.
         
@@ -1041,7 +1029,7 @@ class TradeDB:
                         if candidate is not system:
                             yield candidate, math_sqrt(distSq)
     
-    def genSystemsInRange(self, system, ly, includeSelf=False):
+    def genSystemsInRange(self, system: 'System', ly: float, includeSelf: bool = False)-> Generator[tuple[System, float], Any, None]:
         """
         Yields Systems within a given radius of a specified System.
         Results are sorted by distance and cached for subsequent
@@ -2156,7 +2144,7 @@ class TradeDB:
 ######################################################################
 # Assorted helpers
 
-def describeAge(ageInSeconds: Union[float, int]) -> str:
+def describeAge(ageInSeconds: float | int) -> str:
     """
     Turns an age (in seconds) into a text representation.
     """

--- a/tradedangerous/tradedb.py
+++ b/tradedangerous/tradedb.py
@@ -61,8 +61,10 @@ import heapq
 import itertools
 import locale
 import os
+import pickle
 import re
 import sys
+import time
 import typing
 
 from .tradeenv import TradeEnv
@@ -74,7 +76,8 @@ locale.setlocale(locale.LC_ALL, '')
 from sqlalchemy import func, select, text
 from sqlalchemy.exc import NoResultFound
 from sqlalchemy.orm import Session
-from .db import make_engine_from_config, get_session_factory, healthcheck
+from .db import make_engine_from_config, get_session_factory
+from .db.lifecycle import ensure_fresh_db
 from .db.orm_models import (
     # System, Station, Item, Category, Ship,
     Added,
@@ -121,6 +124,18 @@ from .db.orm_models import (
 
 if typing.TYPE_CHECKING:
     from typing import Any, Callable, Generator, Optional
+
+
+# We should probably just use the trade-dangerous version number
+# otherwise this is a value that someone has to keep changing.
+# Ultimately it just needs to be something that tells us we can't
+# reasonably reconstitute the same data when running this version
+# against that file.
+PERSIST_FORMAT = 1
+
+# Names for the fields in the persist header.
+PERSIST_FORMAT_FIELD = "fmtv"
+PERSIST_TIMESTAMP_FIELD = "dbts"
 
 
 ######################################################################
@@ -559,9 +574,12 @@ class TradeDB:
     trimTrans = str.maketrans('', '', ' \'')
     
     # The DB cache
-    defaultDB = 'TradeDangerous.db'
+    defaultDB: str = 'TradeDangerous.db'
     # File containing SQL to build the DB cache from
-    defaultSQL = 'TradeDangerous.sql'
+    defaultSQL: str = 'TradeDangerous.sql'
+    # The file we persist to. NOT INTENDED TO BE PERMANENT.
+    # We should do the pickling into the database or something.
+    persistFile: str = 'TradeDB.pj'  # "pickle jar"
     # # File containing text description of prices
     # defaultPrices = 'TradeDangerous.prices'
     # array containing standard tables, csvfilename and tablename
@@ -590,9 +608,9 @@ class TradeDB:
     
     def __init__(
             self,
-            tdenv: TradeEnv = None,
-            load:  bool     = True,
-            debug: int|None = None,
+            tdenv: TradeEnv | None = None,
+            load:  bool            = True,
+            debug: int | None      = None,
             ) -> None:
         # --- SQLAlchemy engine/session (replaces sqlite3.Connection) ---
         self.engine = None
@@ -617,6 +635,10 @@ class TradeDB:
         self.sqlPath = dataPath / Path(tdenv.sqlFilename or TradeDB.defaultSQL)
         # pricePath   = Path(tdenv.pricesFilename or TradeDB.defaultPrices)
         # self.pricesPath = dataPath / pricePath
+        
+        # If the database has been deleted, that invalidates any persist file.
+        if not self.dbPath:
+            self.removePersist()
         
         self.importTables = [
             (str(self.csvPath / Path(fn)), tn)
@@ -740,10 +762,10 @@ class TradeDB:
         
         If checks fail (or lifecycle decides to force), it will call buildCache(self, self.tdenv)
         to reset/populate via the authoritative path. Otherwise it is a no-op.
-        """
-        from tradedangerous.db.lifecycle import ensure_fresh_db
-        
         self.tdenv.DEBUG0("reloadCache: engine URL = {}", str(self.engine.url))
+        """
+        
+        kept = False
         
         try:
             summary = ensure_fresh_db(
@@ -756,6 +778,8 @@ class TradeDB:
                 tdenv=self.tdenv,
             )
             action = summary.get("action", "kept")
+            if action == "kept":
+                kept = True
             reason = summary.get("reason")
             if reason:
                 self.tdenv.DEBUG0("reloadCache: ensure_fresh_db → {} (reason: {})", action, reason)
@@ -765,8 +789,9 @@ class TradeDB:
             self.tdenv.WARN("reloadCache: ensure_fresh_db failed: {}", e)
             self.tdenv.DEBUG0("reloadCache: Falling back to buildCache()")
             cache.buildCache(self, self.tdenv)
-
-
+        
+        if not kept:
+            self.removePersist()
     
     ############################################################
     # [deprecated] "added" data.
@@ -792,7 +817,8 @@ class TradeDB:
         Initial load of the list of systems via SQLAlchemy.
         CAUTION: Will orphan previously loaded objects.
         """
-        systemByID, systemByName = {}, {}
+        systemByID = {}
+        started = time.time()
         with self.Session() as session:
             for row in session.query(
                 SA_System.system_id,
@@ -802,7 +828,7 @@ class TradeDB:
                 SA_System.pos_z,
                 SA_System.added_id,
             ):
-                system = System(
+                systemByID[row.system_id] = System(
                     row.system_id,
                     row.name,
                     row.pos_x,
@@ -810,11 +836,10 @@ class TradeDB:
                     row.pos_z,
                     row.added_id,
                 )
-                systemByID[row.system_id] = system
-                systemByName[row.name.upper()] = system
         
-        self.systemByID, self.systemByName = systemByID, systemByName
-        self.tdenv.DEBUG1("Loaded {:n} Systems", len(systemByID))
+        self.systemByID = systemByID
+        self.systemByName = {s.dbname.upper(): s for s in systemByID.values()}
+        self.tdenv.DEBUG1("Loaded {:n} Systems in {:.3f}s", len(systemByID), time.time() - started)
     
     
     def lookupSystem(self, key: str) -> System | None:
@@ -829,6 +854,7 @@ class TradeDB:
         return TradeDB.listSearch(
             "System", key, self.systems(), key=lambda system: system.dbname
         )
+    
     
     def addLocalSystem(
             self,
@@ -1243,6 +1269,7 @@ class TradeDB:
         cached_system = None
         cached_system_id = None
         
+        started = time.time()
         with self.Session() as session:
             # Query all stations
             rows = session.query(
@@ -1261,46 +1288,47 @@ class TradeDB:
                 SA_Station.planetary,
                 SA_Station.type_id,
             )
-            for (
-                ID, systemID, name,
+
+        for (
+            ID, systemID, name,
+            lsFromStar, market, blackMarket, shipyard,
+            maxPadSize, outfitting, rearm, refuel, repair, planetary, type_id
+        ) in rows:
+            isFleet   = 'Y' if type_id in carrier_types else 'N'
+            isOdyssey = 'Y' if type_id == odyssey_type  else 'N'
+            if systemID != cached_system_id:
+                cached_system_id = systemID
+                cached_system = systemByID[cached_system_id]
+            stationByID[ID] = Station(
+                ID, cached_system, name,
                 lsFromStar, market, blackMarket, shipyard,
-                maxPadSize, outfitting, rearm, refuel, repair, planetary, type_id
-            ) in rows:
-                isFleet   = 'Y' if type_id in carrier_types else 'N'
-                isOdyssey = 'Y' if type_id == odyssey_type  else 'N'
-                if systemID != cached_system_id:
-                    cached_system_id = systemID
-                    cached_system = systemByID[cached_system_id]
-                stationByID[ID] = Station(
-                    ID, cached_system, name,
-                    lsFromStar, market, blackMarket, shipyard,
-                    maxPadSize, outfitting, rearm, refuel, repair,
-                    planetary, isFleet, isOdyssey,
-                    0, None,
-                )
-            
-            # Trading station info
-            tradingCount = 0
-            rows = (
-                session.query(
-                    SA_StationItem.station_id,
-                    func.count().label("item_count"),
-                    # Dialect-safe average age in **days**
-                    func.avg(age_in_days(session, SA_StationItem.modified)).label("data_age_days"),
-                )
-                .group_by(SA_StationItem.station_id)
-                .having(func.count() > 0)
+                maxPadSize, outfitting, rearm, refuel, repair,
+                planetary, isFleet, isOdyssey,
+                0, None,
             )
-            
-            for ID, itemCount, dataAge in rows:
-                station = stationByID[ID]
-                station.itemCount = itemCount
-                station.dataAge = dataAge
-                tradingCount += 1
+        
+        # Trading station info
+        tradingCount = 0
+        rows = (
+            session.query(
+                SA_StationItem.station_id,
+                func.count().label("item_count"),
+                # Dialect-safe average age in **days**
+                func.avg(age_in_days(session, SA_StationItem.modified)).label("data_age_days"),
+            )
+            .group_by(SA_StationItem.station_id)
+            .having(func.count() > 0)
+        )
+        
+        for ID, itemCount, dataAge in rows:
+            station = stationByID[ID]
+            station.itemCount = itemCount
+            station.dataAge = dataAge
+            tradingCount += 1
         
         self.stationByID = stationByID
         self.tradingStationCount = tradingCount
-        self.tdenv.DEBUG1("Loaded {:n} Stations", len(stationByID))
+        self.tdenv.DEBUG1("Loaded {:n} Stations in {:.3f}s", len(stationByID), (time.time() - started) * 1000)
         self.stellarGrid = None
 
 
@@ -2052,17 +2080,128 @@ class TradeDB:
         
         self.tdenv.DEBUG1("Loading data")
 
+        # Try and restore the data from the previous load.
+        if not self.readPersist():
+            started = time.time()
+            self._loadSystems()
+            self._loadStations()
+            self._loadCategories()
+            self._loadItems()
+            self.tdenv.DEBUG0("Data load took {:.3f}s", time.time() - started)
 
-        
-        self._loadSystems()
-        self._loadStations()
-        self._loadCategories()
-        self._loadItems()
+            started = time.time()
+            self.writePersist()
+            self.tdenv.DEBUG1("Data persist took {:.3f}s", time.time() - started)
         
         # Calculate the maximum distance anyone can jump so we can constrain
         # the maximum "link" between any two stars.
         msll = maxSystemLinkLy or self.tdenv.maxSystemLinkLy or 30
         self.maxSystemLinkLy = msll
+
+    def getPersistPath(self) -> Path:
+        """ getPersistPath returns the filepath of the file used to store a snapshot
+            of a previously constructed TradeDB object.
+            kfsone: I felt "trade.pickle" would draw confused attention,
+                    so I went with "pj" for 'pickle jar' because it actually
+                    contains two pickles, not just one. """
+        return Path(self.dataPath, TradeDB.persistFile)
+
+    def readPersist(self) -> bool:
+        """ readPersist will attempt to reconstitute the members of TradeDB
+            that were persisted to disk from a previous session. """
+        jarPath = self.getPersistPath()
+        started = time.time()
+        try:
+            with open(jarPath, "rb") as jar:
+                if self._readPickleFrom(jar):
+                    self.tdenv.DEBUG0("Persist load took {:.3f}s", time.time() - started)
+                    return True
+        except FileNotFoundError as e:
+            self.tdenv.DEBUG0("No persistence file to restore: {}: {}", jarPath, e)
+        except pickle.UnpicklingError as e:
+            self.tdenv.DEBUG0("Error restoring persistence data: {}: {}", jarPath, e)
+        except PermissionError as e:
+            self.tdenv.WARN("Unable to reconstitute TradeDB persistence: {}: {}", jarPath, e)
+        except EOFError as e:
+            self.tdenv.WARN("Persistence data appears truncated or corrupt, discarding it: {}: {}", jarPath, e)
+            self.removePersist()
+            self.tdenv.WARN("If this problem keeps happening, please report an issue")
+        return False
+
+    def _readPickleFrom(self, jar: typing.BinaryIO) -> bool:
+        """ Inner implementation that performs the reading from the pickle. """
+        # We pickle a header and then we pickle data.
+        header = pickle.load(jar)
+        if (header_fmt := header.get(PERSIST_FORMAT_FIELD)) != PERSIST_FORMAT:
+            self.tdenv.DEBUG0("persist format mismatch: cur={}, file={}", PERSIST_FORMAT, header_fmt)
+            return False
+
+        # Find when the current database was last modified; if the file doesn't exist,
+        # the caller will see this as a file-not-found exception voiding the read.
+        cur_db_timestamp = self.dbPath.stat().st_mtime
+        # Compare with the timestamp of the previous save.
+        if (old_db_timestamp := header.get(PERSIST_TIMESTAMP_FIELD)) != cur_db_timestamp:
+            self.tdenv.DEBUG0("persist data is stale by timestamp: cur={}, file={}", cur_db_timestamp, old_db_timestamp)
+            return False
+
+        data = pickle.load(jar)
+        eof_marker = pickle.load(jar)
+        if eof_marker != "fin":
+            raise EOFError("missing eof marker in persistence data")
+
+        # We have to repopulate some fields rather than pickle them
+        self.systemByID, self.systemByName = data["system"]
+        self.stationByID, self.tradingStationCount = data["station"]
+        self.categoryByID = data["category"]
+        self.itemByName = data["item"]
+        self.itemByID = {i.ID: i for i in data["item"].values()}
+        self.itemByFDevID = {i.fdevID: i for i in data["item"].values()}
+        
+        return True
+
+    def writePersist(self) -> bool:
+        """ Attempt to restore a snapshotted previous version of our data
+            as long as all the stars align. """
+        # Remove the file if it's already there.
+        jarPath = self.getPersistPath()
+        try:
+            jarPath.unlink(missing_ok=True)
+        except PermissionError as e:
+            if not self.tdenv.persist:
+                # user indicated they don't want to care about persist.
+                return False
+            if jarPath.exists():
+                raise TradeException("Unable to remove old persistence data, the file is inaccssible or open by another program")
+            raise e from e
+
+        try:
+            cur_db_timestamp = self.dbPath.stat().st_mtime
+        except FileNotFoundError:
+            # Can't persist what we don't have
+            self.tdenv.DEBUG0("unable to persist: the db file is dead, Dave")
+            return False
+
+        header = {
+            PERSIST_FORMAT_FIELD: PERSIST_FORMAT,
+            PERSIST_TIMESTAMP_FIELD: cur_db_timestamp
+        }
+        data = {
+            "system":   (self.systemByID, self.systemByName),
+            "station":  (self.stationByID, self.tradingStationCount),
+            "category": self.categoryByID,
+            "item":     self.itemByName,
+        }
+        
+        with jarPath.open("wb") as jar:
+            pickle.dump(header, jar)
+            pickle.dump(data, jar)
+            pickle.dump("fin", jar)  # EOF marker incase user kills process mid-write.
+        
+        return True
+
+    def removePersist(self):
+        self.getPersistPath().unlink(missing_ok=True)
+            
     
     ############################################################
     # General purpose static methods.

--- a/tradedangerous/tradeenv.py
+++ b/tradedangerous/tradeenv.py
@@ -181,6 +181,7 @@ class TradeEnv(Utf8SafeConsoleIOMixin):
         'quiet': 0,
         'color': False,
         'theme': BaseColorTheme(),
+        'persist': bool(os.environ.get('TD_PERSIST', '1')),  # Use the 'persistence' mechanimsm
         'dataDir': os.environ.get('TD_DATA') or os.path.join(os.getcwd(), 'data'),
         'csvDir': os.environ.get('TD_CSV') or os.environ.get('TD_DATA') or os.path.join(os.getcwd(), 'data'),
         'tmpDir': os.environ.get('TD_TMP') or os.path.join(os.getcwd(), 'tmp'),


### PR DESCRIPTION
# Experimental

This branch is [a beginning to] exploring two things:
1- eliminating TradeDB's "fat" types;
2- persisting TradeDB: avoiding repeated construction of rarely-changing fat types (System, Station, Category, Item)

## 1 Eliminate fat types

By "fat types" I mean things like System and Station which are just a fancy data record with some helper methods. The problem is that, now we use the database, we are doing double construction for every System, Station, Item, etc. First the SQLAlchemy record entry and then our pale imitation.

Simultaneously we build our own indexes for them, which means we have to load them in their totality, preventing lazy load/access that SQLAlchemy would provide.

- Eliminated RareItem loading entirely,
- Converted rares sub-command to use the database,
- Eliminated Added loading entirely, made lookupAdded use the database,
- Eliminated Ship loading entirely, made lookupShip use the database with an lru cache to avoid reconstructing the same ship


## 2 Persisting TradeDB

It takes 8-15 seconds for TradeDB() to complete on my machine, so if I run 10 trade commands I've spent a minute waiting for us to build the fat types.

This branch introduces a "persist file" (data/TradeDB.pj for 'pickle jar')..

The persist file gets written with the "blank" slate of Category, Item, System, Station indexes and objects.

Then on subsequent starts, if the persist file is present and readable, we can just restore the objects from the last run. Otherwise, we fallback to loading the old way.

**This is intended to be exploratory -- persisting to a file next to a database is a bit silly**


### Future

- Eliminate the indexes in favor of just querying the database, and/or providing helpers to do that off TradeDB,
- Replace the fat types with thin ones:
```
class Station(SA_Station):
    def name(self) -> str:  return "{self.system.name}/{self.name}"
    ...
```


# Testing

To experiment with this branch, from an existing eyeonus clone:
```
git remote add kfsone https://github.com/kfsone/Trade-Dangerous.git
git pull --all
git switch kfsone/dev/persist
```


