### PR TITLE
Introduce TradeORM and migrate trade_cmd to it.

### DIFF
--- a/tradedangerous/__init__.py
+++ b/tradedangerous/__init__.py
@@ -21,10 +21,11 @@ from a website such as [Tromador's Trading Dangerously](http://elite.ripz.org "T
 from .tradecalc import TradeCalc
 from .tradedb import TradeDB
 from .tradeenv import TradeEnv
+from .tradeorm import TradeORM
 from .version import __version__
 
 
 # Export this as top-level symbnols so they can be imported with e.g.
 #  import tradedangerous.TradeDB
 # rather than forcing everyone to go thru the exacting modules for these.
-__all__ = ['__version__', 'TradeCalc', 'TradeDB', 'TradeEnv']
+__all__ = ['__version__', 'TradeCalc', 'TradeDB', 'TradeEnv', 'TradeORM']

--- a/tradedangerous/commands/commandenv.py
+++ b/tradedangerous/commands/commandenv.py
@@ -85,14 +85,16 @@ class CommandEnv(TradeEnv):
             finally:
                 db_change.unlink()
         
-        self.checkMFD()
-        self.checkFromToNear()
-        self.checkAvoids()
-        self.checkVias()
-        self.checkPadSize()
+        if self.wantsTradeDB:
+            self.checkFromToNear()
+            self.checkAvoids()
+            self.checkVias()
+
         self.checkPlanetary()
         self.checkFleet()
         self.checkOdyssey()
+        self.checkPadSize()
+        self.checkMFD()
         
         results = CommandResults(self)
         return self._cmd.run(results, self, tdb)
@@ -112,6 +114,8 @@ class CommandEnv(TradeEnv):
         self.mfd = X52ProMFD()
     
     def checkFromToNear(self):
+        if not self.wantsTradeDB:
+            return
         
         def check(label, fieldName, wantStation):
             key = getattr(self, fieldName, None)

--- a/tradedangerous/commands/trade_cmd.py
+++ b/tradedangerous/commands/trade_cmd.py
@@ -1,8 +1,14 @@
 # tradedangerous/commands/trade_cmd.py
+import datetime
+
 from .exceptions import CommandLineError
 from .parsing import ParseArgument
-from ..tradecalc import TradeCalc
-from ..formatting import RowFormat, max_len
+from tradedangerous import TradeORM
+from tradedangerous.db import orm_models as models
+from tradedangerous.formatting import RowFormat, max_len
+
+from sqlalchemy import select, text
+from sqlalchemy.orm import aliased
 
 ######################################################################
 # Parser config
@@ -10,7 +16,7 @@ from ..formatting import RowFormat, max_len
 help='Find potential trades between two given stations.'
 name='trade'
 epilog=None
-wantsTradeDB=True
+wantsTradeDB=False
 arguments = [
     ParseArgument(
         'origin',
@@ -24,7 +30,34 @@ arguments = [
     ),
 ]
 switches = [
+    ParseArgument('--gain-per-ton', '--gpt',
+        help = 'Specify the minimum gain per ton of cargo',
+        dest = 'minGainPerTon',
+        type = "credits",
+        default = 1,
+    ),
+    ParseArgument('--limit', '-n',
+        help = 'Limit output to the top N results',
+        dest = 'limit',
+        type = int,
+        default = 0,
+    ),
 ]
+
+
+def age(now: datetime, modified: datetime) -> float:
+    """ Return age in hours between now and modified timestamp. """
+    delta = (now - modified).total_seconds() / 60.0
+    if delta < 90:
+        return f"{delta:.1f}M"
+    delta /= 60.0
+    if delta < 25:
+        return f"{delta:.1f}H"
+    delta /= 7.0
+    if delta < 7:
+        return f"{delta:.1f}D"
+    return f"{int(delta):n}D"
+
 
 ######################################################################
 # Perform query and populate result set
@@ -33,31 +66,75 @@ def run(results, cmdenv, tdb):
     from .commandenv import ResultRow
 
     # IMPORTANT: resolve stations BEFORE constructing TradeCalc
-    lhs = cmdenv.startStation
-    rhs = cmdenv.stopStation
+    tdb = TradeORM(tdenv=cmdenv)
+
+    lhs = tdb.lookup_station(cmdenv.origin)
+    if not lhs:
+        raise CommandLineError(f"Unknown origin station: {cmdenv.origin}")
+    cmdenv.DEBUG0("from id: system={}, station={}", lhs.system_id, lhs.station_id)
+    rhs = tdb.lookup_station(cmdenv.dest)
+    if not rhs:
+        raise CommandLineError(f"Unknown destination station: {cmdenv.dest}")
+    cmdenv.DEBUG0("to id..: system={}, station={}", rhs.system_id, rhs.station_id)
 
     if lhs == rhs:
         raise CommandLineError("Must specify two different stations.")
+    
+    seller = aliased(models.StationItem, name="seller")
+    buyer = aliased(models.StationItem, name="buyer")
+    stmt = (
+        select(
+            models.Item,
+            seller.supply_price, seller.supply_units, seller.supply_level,
+            buyer.demand_price, buyer.demand_units, buyer.demand_level,
+            seller.modified, buyer.modified,
+        )
+        .where(
+            seller.station_id == lhs.station_id,
+            buyer.station_id == rhs.station_id,
+            seller.item_id == buyer.item_id,
+            seller.supply_price > 0,
+            buyer.demand_price > 0,                 # (optional extra guard)
+            buyer.demand_price >= seller.supply_price,
+            seller.item_id == models.Item.item_id,
+        )
+        .order_by((buyer.demand_price - seller.supply_price).desc())
+    )
+    compiled = stmt.compile(
+        dialect=tdb.session.bind.dialect,
+        compile_kwargs={"literal_binds": True}
+    )
+    cmdenv.DEBUG1("query: {}", compiled)
+    trades = tdb.session.execute(stmt).unique().all()
+    cmdenv.DEBUG0("Raw result count: {}", len(trades))
+    if not trades:
+        raise CommandLineError(f"No profitable trades {lhs.name} -> {rhs.name}")
 
-    # NEW: restrict preload strictly to these two station IDs
-    calc = TradeCalc(tdb, cmdenv, restrict_station_ids=(lhs.ID, rhs.ID))
-
-    results.summary = ResultRow()
+    results.summary = ResultRow(color=cmdenv.color)
     results.summary.fromStation = lhs
     results.summary.toStation = rhs
 
-    trades = calc.getTrades(lhs, rhs)
-    if not trades:
-        raise CommandLineError("No profitable trades {} -> {}".format(
-            lhs.name(), rhs.name()
-        ))
+    now = datetime.datetime.now(tz=datetime.timezone.utc)
+    
+    if cmdenv.limit > 0:
+        trades = trades[:cmdenv.limit]
 
-    if cmdenv.detail > 1:
-        tdb.getAverageSelling()
-        tdb.getAverageBuying()
-
-    for item in trades:
-        results.rows.append(item)
+    for item, sup_price, sup_units, sup_level, dem_price, dem_units, dem_level, sup_age, dem_age in trades:
+        gain = dem_price - sup_price
+        if gain < cmdenv.minGainPerTon:
+            continue
+        results.rows.append({
+            "item": item.dbname(cmdenv.detail),
+            "sup_price": sup_price,
+            "sup_units": sup_units,
+            "sup_level": sup_level,
+            "dem_price": dem_price,
+            "dem_units": dem_units,
+            "dem_level": dem_level,
+            "sup_age": age(now, sup_age),
+            "dem_age": age(now, dem_age),
+            "gain": gain,
+        })
 
     return results
 
@@ -65,37 +142,38 @@ def run(results, cmdenv, tdb):
 ## Transform result set into output
 
 def render(results, cmdenv, tdb):
-    longestNameLen = max_len(results.rows, key=lambda row: row.item.name(cmdenv.detail))
+    longestNameLen = max_len(results.rows, key=lambda row: row["item"])
 
     rowFmt = RowFormat()
     rowFmt.addColumn('Item', '<', longestNameLen,
-            key=lambda row: row.item.name(cmdenv.detail))
+            key=lambda row: row["item"])
     rowFmt.addColumn('Profit', '>', 10, 'n',
-            key=lambda row: row.gainCr)
+            key=lambda row: row["gain"])
     rowFmt.addColumn('Cost', '>', 10, 'n',
-            key=lambda row: row.costCr)
-    if cmdenv.detail > 1:
-        rowFmt.addColumn('AvgCost', '>', 10,
-            key=lambda row: tdb.avgSelling.get(row.item.ID, 0)
-        )
-        rowFmt.addColumn('Buying', '>', 10,
-            key=lambda row: row.costCr + row.gainCr
-        )
-        rowFmt.addColumn('AvgBuy', '>', 10,
-            key=lambda row: tdb.avgBuying.get(row.item.ID, 0)
-        )
+            key=lambda row: row["sup_price"])
+    # if cmdenv.detail > 1:
+    #     rowFmt.addColumn('AvgCost', '>', 10,
+    #         key=lambda row: tdb.avgSelling.get(row.item.ID, 0)
+    #     )
+    rowFmt.addColumn('Buying', '>', 10, 'n',
+            key=lambda row: row["dem_price"])
+        # rowFmt.addColumn('AvgBuy', '>', 10,
+        #     key=lambda row: tdb.avgBuying.get(row.item.ID, 0)
+        # )
 
-    if cmdenv.detail:
+    if cmdenv.detail > 1:
         rowFmt.addColumn('Supply', '>', 10,
-            key=lambda row: '{:n}'.format(row.supply) if row.supply >= 0 else '?')
+            key=lambda row: f'{row["sup_units"]:n}' if row["sup_units"] >= 0 else '?')
         rowFmt.addColumn('Demand', '>', 10,
-            key=lambda row: '{:n}'.format(row.demand) if row.demand >= 0 else '?')
-        rowFmt.addColumn('SrcAge', '>', 8, '.2f',
-            key=lambda row: (row.srcAge / 86400))
-        rowFmt.addColumn('DstAge', '>', 8, '.2f',
-            key=lambda row: (row.dstAge / 86400))
+            key=lambda row: f'{row["dem_units"]:n}' if row["dem_units"] >= 0 else '?')
+    if cmdenv.detail:
+        rowFmt.addColumn('SrcAge', '>', 9, 's',
+            key=lambda row: row["sup_age"])
+        rowFmt.addColumn('DstAge', '>', 9, 's',
+            key=lambda row: row["dem_age"])
 
     if not cmdenv.quiet:
+        print(f"{len(results.rows)} trades found between {results.summary.fromStation.dbname()} and {results.summary.toStation.dbname()}.")
         heading, underline = rowFmt.heading()
         print(heading, underline, sep='\n')
 

--- a/tradedangerous/db/engine.py
+++ b/tradedangerous/db/engine.py
@@ -7,7 +7,7 @@ import configparser
 
 from sqlalchemy import create_engine, event, text
 from sqlalchemy.engine import Engine, URL
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import sessionmaker, Session  # type: ignore
 from sqlalchemy.pool import NullPool
 from sqlalchemy.exc import OperationalError
 
@@ -209,7 +209,7 @@ def make_engine_from_config(cfg_or_path: configparser.ConfigParser | Mapping[str
     return engine
 # ---------- Session factory ----------
 
-def get_session_factory(engine: Engine):
+def get_session_factory(engine: Engine) -> sessionmaker[Session]:
     return sessionmaker(bind=engine, expire_on_commit=False, autoflush=True)
 
 # ---------- Health helpers ----------

--- a/tradedangerous/db/orm_models.py
+++ b/tradedangerous/db/orm_models.py
@@ -1,6 +1,7 @@
 # tradedangerous/db/orm_models.py
 from __future__ import annotations
 
+import datetime
 from typing import Optional
 
 from sqlalchemy import (
@@ -43,7 +44,7 @@ def _default_now(element, compiler, **kw):
 
 
 class DateTime6(TypeDecorator):
-    """DATETIME that is DATETIME(6) on MySQL/MariaDB, generic DateTime elsewhere."""
+    """DATETIME that is DATETIME(6) on MySQL/MariaDB, generic DateTime elsewhere. Always UTC."""
     impl = DateTime
     cache_ok = True
     
@@ -51,7 +52,14 @@ class DateTime6(TypeDecorator):
         if dialect.name in ("mysql", "mariadb"):
             from sqlalchemy.dialects.mysql import DATETIME as _MYSQL_DATETIME
             return dialect.type_descriptor(_MYSQL_DATETIME(fsp=6))
-        return dialect.type_descriptor(DateTime())
+        return dialect.type_descriptor(DateTime(timezone=True))
+    
+    def process_result_value(self, value, dialect):
+        """Ensure all datetimes loaded from DB are UTC-aware."""
+        if value is not None and value.tzinfo is None:
+            # Database stored naive datetime; treat it as UTC
+            return value.replace(tzinfo=datetime.timezone.utc)
+        return value
 
 
 # ---------- Dialect Helpers --------
@@ -141,6 +149,9 @@ class System(Base):
         nullable=False,
     )
     
+    def dbname(self) -> str:
+        return f"{self.name.upper()}/"
+    
     # Relationships
     added: Mapped[Optional["Added"]] = relationship(back_populates="systems")
     stations: Mapped[list["Station"]] = relationship(back_populates="system", cascade="all, delete-orphan")
@@ -158,6 +169,9 @@ class Station(Base):
     
     station_id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
     name: Mapped[str] = mapped_column(CIString(128), nullable=False)
+    
+    def dbname(self) -> str:
+        return f"{self.system.name}/{self.name}"
     
     # type widened; cascade semantics unchanged (DELETE only)
     system_id: Mapped[int] = mapped_column(
@@ -216,6 +230,10 @@ class Item(Base):
         ForeignKey("Category.category_id", onupdate="CASCADE", ondelete="CASCADE"),
         nullable=False,
     )
+    def dbname(self, detail: int | bool = 0) -> str:
+        if detail:
+            return f"{self.category.name}/{self.name}"
+        return self.name
     ui_order: Mapped[int] = mapped_column(Integer, nullable=False, server_default=text("0"))
     avg_price: Mapped[int | None] = mapped_column(Integer)
     fdev_id: Mapped[int | None] = mapped_column(Integer)

--- a/tradedangerous/plugins/eddblink_plug.py
+++ b/tradedangerous/plugins/eddblink_plug.py
@@ -124,6 +124,7 @@ class ImportPlugin(plugins.ImportPluginBase):
         'optimize':     "Optimize ('vacuum') database after processing.",
         'solo':         "Don't download crowd-sourced market data. (Implies '-O skipvend', supercedes '-O all', '-O clean', '-O listings'.)",
         '7days':        "Ignore data more than 7 days old during import, and expire old records after import.",
+        'bootstrap':    "Helper to 'do the right thing' and get you some data",
     }
     
     def __init__(self, tdb, tdenv):
@@ -304,6 +305,9 @@ class ImportPlugin(plugins.ImportPluginBase):
                         if listing_time < time_cutoff:
                             continue
                         dt_listing_time = from_timestamp(listing_time, utc)
+
+                        if listing[5] == "0" and listing[6] == "0":
+                            continue
                         
                         row = {
                             "station_id":   station_id,
@@ -375,10 +379,18 @@ class ImportPlugin(plugins.ImportPluginBase):
         # Enable 'listings' by default unless other explicit options are present
         default = True
         for option in self.options:
-            if option not in ('force', 'skipvend', 'purge'):
+            if option not in ('force', 'skipvend', 'purge', '7days'):
                 default = False
         if default:
             self.options["listings"] = True
+        
+        if self.getOption("bootstrap"):
+            self.tdenv.NOTE("[bold][blue]bootstrap: Greetings, Commander!")
+            self.tdenv.NOTE("[yellow]This first-time import might take several minutes or longer, it ensures your database is up to date with current EDDBLink System, Station, and Item tables as well as trade listings for the last 7 days.")
+            self.tdenv.NOTE("[yellow]You can run this same command later to import updates - which should be much faster, or `trade import -P eddblink -O 7days,skipvend`.")
+            self.tdenv.NOTE("[yellow]To contribute your own discoveries to market data, consider running the Elite Dangerous Market Connector while playing.")
+            for child in ["system", "station", "item", "listings", "skipvend", "7days"]:
+                self.options[child] = True
         
         # Check if database already exists and enable `clean` if not.
         if lifecycle.is_empty(self.tdb.engine):
@@ -407,8 +419,7 @@ class ImportPlugin(plugins.ImportPluginBase):
             
             self.options["all"] = True
             self.options["force"] = True
-        
-        
+
         # Select which options will be updated
         if self.getOption("listings"):
             self.options["item"] = True

--- a/tradedangerous/tradedb.py
+++ b/tradedangerous/tradedb.py
@@ -68,7 +68,7 @@ import time
 import typing
 
 from .tradeenv import TradeEnv
-from .tradeexcept import TradeException
+from .tradeexcept import TradeException, AmbiguityError, SystemNotStationError
 from . import cache, fs
 
 from sqlalchemy import func, select, text
@@ -129,98 +129,6 @@ PERSIST_SIZE_FIELD = "dbsz"
 
 ######################################################################
 # Classes
-
-class AmbiguityError(TradeException):
-    """
-        Raised when a search key could match multiple entities.
-
-        Attributes:
-            lookupType - description of what was being queried,
-            searchKey  - the key given to the search routine,
-            anyMatch   - list of items which were found to match, if any
-            key        - retrieve the display string for a candidate
-    """
-    def __init__(self, lookupType, searchKey, anyMatch, key=None):
-        """
-        Args:
-            lookupType
-                A string identifying what type of lookup is matching,
-                e.g. 'Item' or 'System'. This is used in the error
-                message to help the user understand what they were
-                looking for.
-            searchKey
-                The search key the user provided, e.g. "sol"
-            anyMatch
-                A list of any values that matched the key.
-            key
-                A callable which, given a candidate object from anyMatch,
-                returns a display string for that candidate.
-        """
-        if key is None:
-            key = lambda candidate: candidate
-        self.lookupType = lookupType
-        self.searchKey = searchKey
-        self.anyMatch = anyMatch
-        self.key = key
-
-    def __str__(self):
-        anyMatch, key = self.anyMatch, self.key
-
-        # ------------------------------------------------------------------
-        # Special-case: system name collisions where we passed in
-        # (index, System) pairs from TradeDB.lookupSystem.
-        # ------------------------------------------------------------------
-        if (
-            self.lookupType == "System"
-            and anyMatch
-            and isinstance(anyMatch[0], tuple)
-            and len(anyMatch[0]) >= 2
-        ):
-            lines = [
-                f'System name "{self.searchKey}" refers to more than one distinct system.',
-                "",
-                'Select the one you intended using "@N":',
-                "",
-            ]
-            for index, system in anyMatch:
-                # Be tolerant in case the contents are not exactly (int, System)
-                try:
-                    name = system.dbname
-                    x, y, z = system.posX, system.posY, system.posZ
-                    lines.append(
-                        f"    {name}@{index} — ({x:.1f}, {y:.1f}, {z:.1f})"
-                    )
-                except Exception:
-                    # Fallback to the provided key() formatter
-                    lines.append(f"    {key((index, system))}")
-            lines.append("")
-            lines.append("(Index numbers are ordered by Galactic X coordinate.)")
-            return "\n".join(lines)
-
-        # ------------------------------------------------------------------
-        # Generic ambiguity formatting used everywhere else
-        # ------------------------------------------------------------------
-        if not anyMatch:
-            return f'{self.lookupType} "{self.searchKey}" could match nothing.'
-
-        if len(anyMatch) > 10:
-            opportunities = ", ".join([key(c) for c in anyMatch[:10]] + ["." ])
-        elif len(anyMatch) == 1:
-            opportunities = key(anyMatch[0])
-        else:
-            opportunities = ", ".join(key(c) for c in anyMatch[:-1])
-            opportunities += " or " + key(anyMatch[-1])
-
-        return f'{self.lookupType} "{self.searchKey}" could match {opportunities}'
-
-    
-class SystemNotStationError(TradeException):
-    """
-        Raised when a station lookup matched a System but
-        could not be automatically reduced to a Station.
-    """
-    pass  # pylint: disable=unnecessary-pass  # (it's not)
-
 
 ######################################################################
 

--- a/tradedangerous/tradeexcept.py
+++ b/tradedangerous/tradeexcept.py
@@ -1,3 +1,21 @@
+"""
+tradeexcept defines standard exceptions used within TradeDangerous.
+"""
+from __future__ import annotations
+import typing
+
+if typing.TYPE_CHECKING:
+    try:
+        from collections.abc import Callable
+    except ImportError:
+        from typing import Callable
+    from typing import Any
+    from pathlib import Path
+
+
+AMBIGUITY_LIMIT = 6
+
+
 class TradeException(Exception):
     """
         Distinguishes runtime logical errors (such as no data for what you
@@ -8,3 +26,99 @@ class TradeException(Exception):
         most user friendly way possible.
     """
     pass
+
+
+class MissingDB(TradeException):
+    """
+        Reports that the database is missing in a scenario where it is
+        required and not default-created for the user.
+
+        Ideally, this should describe to the user how to create the
+        database, perhaps through a "bootstrap" subcommand.
+    """
+    def __init__(self, dbpath: str | Path):
+        super().__init__(
+            f"{dbpath}: Data file(s) are missing, you must initialize the database first. "
+            "Consider using `trade import -Peddblink -Obootstrap` or if you are "
+            "managing data by hand, use the buildcache subcommand."
+        )
+
+class AmbiguityError(TradeException):
+    """
+        Raised when a search key could match multiple entities.
+        Attributes:
+            lookupType - description of what was being queried,
+            searchKey  - the key given to the search routine,
+            anyMatch   - list of items which were found to match, if any
+            key        - retrieve the display string for a candidate
+    """
+    def __init__(
+            self,
+            lookupType: str,
+            searchKey: str,
+            anyMatch: list[Any],
+            key: Callable[[Any], str] = lambda item: item
+            ) -> None:
+        self.lookupType = lookupType
+        self.searchKey = searchKey
+        self.anyMatch = anyMatch
+        self.key = key
+    
+    def __str__(self) -> str:
+        anyMatch, key = self.anyMatch, self.key
+
+        # ------------------------------------------------------------------
+        # Special-case: system name collisions where we passed in
+        # (index, System) pairs from TradeDB.lookupSystem.
+        # ------------------------------------------------------------------
+        if (
+            self.lookupType == "System"
+            and anyMatch
+            and isinstance(anyMatch[0], tuple)
+            and len(anyMatch[0]) >= 2
+        ):
+            lines = [
+                f'System name "{self.searchKey}" refers to more than one distinct system.',
+                "",
+                'Select the one you intended using "@N":',
+                "",
+            ]
+            for index, system in anyMatch:
+                # Be tolerant in case the contents are not exactly (int, System)
+                try:
+                    name = system.dbname
+                    x, y, z = system.posX, system.posY, system.posZ
+                    lines.append(
+                        f"    {name}@{index} 45 ({x:.1f}, {y:.1f}, {z:.1f})"
+                    )
+                except Exception:
+                    # Fallback to the provided key() formatter
+                    lines.append(f"    {key((index, system))}")
+            lines.append("")
+            lines.append("(Index numbers are ordered by Galactic X coordinate.)")
+            return "\n".join(lines)
+
+        # ------------------------------------------------------------------
+        # Generic ambiguity formatting used everywhere else
+        # ------------------------------------------------------------------
+        if not anyMatch:
+            # Not matching anything is not "ambiguous".
+            raise RuntimeError('called AmbiguityError with no matches')
+
+        # Truncate the list of candidates so we don't show more than 10
+        candidates = [key(c) for c in anyMatch[:AMBIGUITY_LIMIT]]
+        if len(anyMatch) < 3:
+            opportunities = " or ".join(candidates)
+        else:
+            if len(anyMatch) > AMBIGUITY_LIMIT:
+                candidates[-1] = "..."
+            else:
+                candidates[-1] = "or " + candidates[-1]  # oxford comma
+            opportunities = ", ".join(candidates)
+
+        return f'{self.lookupType} "{self.searchKey}" could match {opportunities}'
+
+
+class SystemNotStationError(TradeException):
+    """ Raised when a station lookup matched a System but
+        could not be automatically reduced to a Station.  """

--- a/tradedangerous/tradeexcept.py
+++ b/tradedangerous/tradeexcept.py
@@ -39,7 +39,7 @@ class MissingDB(TradeException):
     def __init__(self, dbpath: str | Path):
         super().__init__(
             f"{dbpath}: Data file(s) are missing, you must initialize the database first. "
-            "Consider using `trade import -Peddblink -Obootstrap` or if you are "
+            "Consider using `trade import -P eddblink -O bootstrap` or if you are "
             "managing data by hand, use the buildcache subcommand."
         )
 

--- a/tradedangerous/tradeorm.py
+++ b/tradedangerous/tradeorm.py
@@ -1,0 +1,177 @@
+"""
+tradeorm provides the TradeORM class which uses the sqlite3 database
+rather than trying to be its own database in its own right like TradeDB.
+"""
+from __future__ import annotations
+from pathlib import Path
+import os
+import typing
+
+from . import TradeEnv
+from .tradeexcept import AmbiguityError, TradeException, MissingDB, SystemNotStationError
+from .db import (
+    orm_models as orm,          # type: ignore  # so we can access models easily
+    make_engine_from_config,    # type: ignore
+    get_session_factory,        # type: ignore
+)
+
+if typing.TYPE_CHECKING:
+    from .db.engine import sessionmaker, Engine, Session  # type: ignore
+
+
+class TradeORM:
+    DEFAULT_PATH = "data"
+    DEFAULT_DB = "TradeDangerous.db"
+    DB_CONFIG_VAR = "TD_DB_CONFIG"
+    DB_CONFIG_FILE = "db_config.ini"
+
+    data_dir: Path
+    db_path:  Path
+
+    engine: Engine
+    session_maker: sessionmaker[Session]
+    session: Session
+
+    def __init__(self, *, tdenv: TradeEnv | None = None, debug: int | None = None):
+        tdenv = tdenv or TradeEnv(debug=debug or 0)
+        self.tdenv = tdenv
+
+        # Determine where the database should be
+        data_dir = tdenv.dataDir or TradeORM.DEFAULT_PATH
+        self.data_dir = Path(data_dir)
+        tdenv.DEBUG0("data_dir = {}", self.data_dir)
+
+        # Determine the path to the file itself
+        db_path = tdenv.dbFilename or (self.data_dir / TradeORM.DEFAULT_DB)
+        self.db_path  = Path(db_path)
+        tdenv.DEBUG0("db_path = {}", self.db_path)
+
+        # We need it to exist.
+        if not self.db_path.exists():
+            raise MissingDB(self.db_path)
+
+        default_config = self.data_dir / TradeORM.DB_CONFIG_FILE
+        db_config = os.environ.get(TradeORM.DB_CONFIG_VAR, default_config)
+        tdenv.DEBUG0("db_config = {}", db_config)
+
+        # Make the database available.
+        self.engine = make_engine_from_config(db_config)
+
+        # The user will expect objects (instances of models) that we return
+        # to have the same lifetime as the TradeORM() instance, so we want
+        # a main session for things to use and return from.
+        #
+        # However: we also want them to be able to create transactions, etc
+        # so we also make the session-factory available.
+        self.session_maker = get_session_factory(self.engine)
+        self.session = self.session_maker()
+
+    def __enter__(self) -> Session:
+        return self.session_maker().begin()
+
+    def __exit__(self, _exc_type, _exc_value, _traceback) -> None:
+        pass
+
+    def lookup_station(self, name: str) -> orm.Station | None:
+        """ Use the database to lookup a station, which accepts a name that
+            is either a unique station name (or partial of one), or in the
+            'system name/station name' component. If the station does not
+            match a unique station, raises an AmbiguityError
+        """
+        if "%" in name:
+            raise TradeException("wildcards ('%') are not supported in station names")
+        if "/" not in name:
+            if (station := self._station_lookup(name, exact=True, partial=False)):
+                return station
+            if self._system_lookup(name, exact=True, partial=False):
+                raise SystemNotStationError(f'"{name}" is a system name, use "/{name}" if you meant it as a station')
+            name = "/" + name
+        station: orm.Station | None = self.lookup_place(name)
+        return station
+
+    def lookup_system(self, name: str) -> orm.System | None:
+        """ Use the database to lookup a system, which accepts a name that
+            is either a unique system name (or partial of one), or in the
+            'system name/station name' component. If the system does not
+            match a unique system, raises an AmbiguityError
+        """
+        if "%" in name:
+            raise TradeException("wildcards ('%') are not supported in system names")
+        system_name, _, _ = name.partition("/")
+        if not system_name:
+            raise TradeException(f"system name required for system lookup, got {name}")
+        result: orm.Station | orm.System | None = self.lookup_place(system_name)
+        if isinstance(result, orm.Station):
+            return result.system
+        return result
+
+    def lookup_place(self, name: str) -> orm.Station | orm.System | None:
+        """ Using a "[<system>]/[<station>]" style name, look up either a Station or a System."""
+        if "%" in name:
+            raise TradeException("wildcards ('%') are not supported in names")
+        sys_name, slashed, stn_name = name.partition("/")
+        if not slashed:
+            if stn_name:
+                station: orm.Station | None = self._station_lookup(stn_name, exact=True, partial=False)
+                if station:
+                    return station
+            if sys_name:
+                system: orm.System | None = self._system_lookup(sys_name, exact=True, partial=False)
+                if system:
+                    return system
+
+        if sys_name:
+            system = self._system_lookup(sys_name)
+            if not system:
+                raise TradeException(f"unknown system: {sys_name}")
+            if not stn_name:
+                return system
+            
+            # Now we match the list of station names for this system.
+            stmt = self.session.query(orm.Station).filter(orm.Station.system_id == system.system_id).filter(orm.Station.name == stn_name)
+            results = stmt.all()
+            if len(results) == 1:
+                return results[0]
+            stmt = self.session.query(orm.Station).filter(orm.Station.system_id == system.system_id).filter(orm.Station.name.like(f"%{stn_name}%"))
+            results = stmt.all()
+            if len(results) > 1:
+                raise AmbiguityError("Station", stn_name, [s.name for s in results])
+            return results[0]
+
+        station = self._station_lookup(stn_name, exact=False)
+        return station
+
+    def _system_lookup(self, name: str, *, exact: bool = True, partial: bool = True) -> orm.System | None:
+        """ Look up a model by exact name match. """
+        assert exact or partial, "at least one of exact or partial must be True"
+        results: list[orm.System] | None = None
+        if exact:
+            results = self.session.query(orm.System).filter(orm.System.name == name).all()
+            if len(results) == 1:
+                partial = False
+        if partial:
+            like_pattern = f"%{name}%"
+            results = self.session.query(orm.System).filter(orm.System.name.like(like_pattern)).all()
+
+        if not results:
+            return None
+        if len(results) > 1:
+            raise AmbiguityError("System", name, results, key=lambda s: s.dbname())
+        return results[0]
+
+    def _station_lookup(self, name: str, *, exact: bool = True, partial: bool = True) -> orm.Station | None:
+        """ Look up a model by exact name match. """
+        assert exact or partial, "at least one of exact or partial must be True"
+        results: list[orm.Station] | None = None
+        if exact:
+            results = self.session.query(orm.Station).filter(orm.Station.name == name).all()
+            if len(results) == 1:
+                partial = False
+        if partial:
+            like_pattern = f"%{name}%"
+            results = self.session.query(orm.Station).filter(orm.Station.name.like(like_pattern)).all()
+        if not results:
+            return None
+        if len(results) > 1:
+            raise AmbiguityError("Station", name, results, key=lambda s: s.dbname())
+        return results[0]

--- a/tradedangerous/tradeorm.py
+++ b/tradedangerous/tradeorm.py
@@ -1,6 +1,15 @@
 """
 tradeorm provides the TradeORM class which uses the sqlite3 database
 rather than trying to be its own database in its own right like TradeDB.
+
+Suggested use:
+
+    # TradeEnv is optional, it's for controlling environment settings
+    # builder-pattern style.
+    from tradedangerous import TradeEnv, TradeORM
+
+    tde = TradeEnv()  # debug settings, color, etc...
+    tdo = TradeORM(tde)  # if not supplied, it will make its own
 """
 from __future__ import annotations
 from pathlib import Path
@@ -63,14 +72,11 @@ class TradeORM:
         #
         # However: we also want them to be able to create transactions, etc
         # so we also make the session-factory available.
-        self.session_maker = get_session_factory(self.engine)
-        self.session = self.session_maker()
+        self.session = get_session_factory(self.engine)()
 
-    def __enter__(self) -> Session:
-        return self.session_maker().begin()
-
-    def __exit__(self, _exc_type, _exc_value, _traceback) -> None:
-        pass
+    def commit(self):
+        """ Commit the current transaction state. """
+        return self.session.commit()
 
     def lookup_station(self, name: str) -> orm.Station | None:
         """ Use the database to lookup a station, which accepts a name that


### PR DESCRIPTION
- Fixes CommandEnv ignoring wantsTradeDB = False and trying to resolve arguments with it,
- Adds tradeorm.TradeORM which is a thin wrapper around simple SQLAlchemy access,
- - implements less-complex "partial" lookups (doesn't do name mangling)
- - supports dedicated "<system>/<station>" name structure, so "/aham" means 'station(s) with aham in their name in any system" and "Sol/" is definitively a system name
- - implements exact matches first so "Sol" will find "Sol" before trying "%sol%" in stations,
- Adds "bootstrap" option to eddblink plugin to assist in and hint at database setup,
```
(Trade-Dangerous) PS E:\Elite\Trade-Dangerous> python trade.py import -Peddblink -Obootstrap
NOTE: bootstrap: Greetings, Commander!
NOTE: This first-time import might take several minutes or longer, it ensures your database is up to date with current EDDBLink System, Station, and Item tables as well as trade listings for the last 7 days.
NOTE: You can run this same command later to import updates - which should be much faster, or `trade import -P eddblink -O 7days,skipvend`.
NOTE: To contribute your own discoveries to market data, consider running the Elite Dangerous Market Connector while playing.
NOTE: Checking for update to 'System.csv'.
NOTE: Checking for update to 'Station.csv'.
NOTE: Checking for update to 'Item.csv'.
NOTE: Checking for update to 'listings.csv'.
NOTE: Checking for update to 'listings-live.csv'.
NOTE: Downloading file 'listings-live.csv'.
NOTE: Requesting https://elite.tromador.com/files/listings-live.csv
```
- Adds "MissingDB" exception which refers the user to the above,
- - this is because TradeORM doesn't create databases...
- Migrates "trade trade" subcommand to using the new TradeORM,
- Adds a couple of extra switches to "trade"

```
(Trade-Dangerous) PS E:\Elite\Trade-Dangerous> python trade.py trade "sol/abraham lincoln" "reorte/davies"
 Item                                  Profit       Cost     Buying
-------------------------------------------------------------------
 Monazite                             103,046    121,396    224,442
 Large Survey Data Cache               27,091    199,648    226,739
 Small Survey Data Cache               24,620     16,932     41,552
 Low Temperature Diamonds              17,426     47,202     64,628
 Geological Samples                     8,401      4,389     12,790
 Scientific Samples                     7,558      3,961     11,519
 Samarium                               6,585     17,579     24,164
 Scientific Research                    4,428      9,695     14,123
 Performance Enhancers                  2,847      4,749      7,596
 Tritium                                2,319     40,111     42,430
 Aquaponic Systems                      2,257        173      2,430
 Land Enrichment Systems                2,228      3,404      5,632
 Marine Equipment                       2,049      2,962      5,011
 Lepidolite                             1,450        398      1,848
 Crop Harvesters                        1,384      1,499      2,883
 Rutile                                 1,210      1,312      2,522
 Bauxite                                1,173        641      1,814
 Haematite                              1,055      1,152      2,207
 Coquim Spongiform Victuals             1,013        208      1,221
 Agri-Medicines                           949        685      1,634
 Harma Silver Sea Rum                     909      2,139      3,048
 Atmospheric Processors                   690        267        957
 Animal Monitors                          648        192        840
 Pesticides                               637        173        810
 Jaroua Rice                              572        313        885
 Biowaste                                 560        109        669
 Damna Carapaces                          559        256        815
 Natural Fabrics                          493        267        760
 Mulachi Giant Fungus                     484         70        554
 Buckyball Beer Mats                      484         70        554
 Rapa Bao Snake Skins                     435        446        881
 Rajukru Multi-Stoves                     431        552        983
 Toxandji Virocide                        423        434        857
 Eden Apples of Aerial                    418        498        916
 Vanayequi Ceratomorpha Fur               418        498        916
 Njangari Saddles                         410        527        937
 Live Hecate Sea Worms                    409        963      1,372
 Wulpa Hyperbore Systems                  403        951      1,354
 Kongga Ale                               398        474        872
 Mineral Oil                              397        108        505
 Lavian Brandy                            391      2,830      3,221
 Wuthielo Ku Froth                        386        341        727
 Neritus Berries                          381        688      1,069
 HR 7221 Wheat                            381        337        718
 Delta Phoenicis Palms                    379        334        713
 Deuringas Truffles                       378      1,530      1,908
 Belalans Ray Leather                     374        714      1,088
 Bast Snake Gin                           371        874      1,245
 Ochoeng Chillies                         368        807      1,175
 Eleu Thermals                            366        699      1,065
 Nguna Modern Antiques                    360        744      1,104
 Utgaroar Millennial Eggs                 358      1,452      1,810
 Karsuki Locusts                          358        741      1,099
 The Hutton Mug                           358        103        461
 Baltah'sine Vacuum Krill                 349        668      1,017
 Kachirigin Filter Leeches                344        378        722
 Any Na Coffee                            343      1,448      1,791
 Thrutis Cream                            340        749      1,089
 Ceti Rabbits                             334      1,355      1,689
 Chi Eridani Marine Paste                 332        635        967
 Alacarakmo Skin Art                      330      1,149      1,479
 Witchhaul Kobe Beef                      324      3,654      3,978
 Tiolce Waste2Paste Units                 323        933      1,256
 Xihe Biomorphic Companions               323      3,622      3,945
 HIP Proto-Squid                          322      1,203      1,525
 Giant Irukama Snails                     318      1,464      1,782
 Goman Yaupon Coffee                      314      1,173      1,487
 V Herculis Body Rub                      310        131        441
 Albino Quechua Mammoth Meat              305      2,052      2,357
 Void Extract Coffee                      301      1,899      2,200
 Mokojing Beast Feast                     301      2,167      2,468
 Aepyornis Egg                            297      2,146      2,443
 Azure Milk                               297      3,332      3,629
 Saxon Wine                               295      1,246      1,541
 Esuseku Caviar                           293      1,981      2,274
 Chameleon Cloth                          292      1,346      1,638
 Ceremonial Heike Tea                     291      1,553      1,844
 Helvetitj Pearls                         290      2,926      3,216
 Mechucos High Tea                        290      1,088      1,378
 Jotun Mookah                             290      1,013      1,303
 Centauri Mega Gin                        289      2,659      2,948
 Haiden Black Brew                        288      1,077      1,365
 Ethgreze Tea Buds                        287      2,636      2,923
 Vega Slimweed                            287      1,939      2,226
 Shan's Charis Orchid                     285      1,315      1,600
 LTT Hyper Sweet                          281        180        461
 Tauri Chimes                             281        748      1,029
 Onionhead Beta Strain                    281        620        901
 Ophiuch Exino Artefacts                  280      3,520      3,800
 Apa Vietii                               280      2,825      3,105
 Altairian Skin                           279        614        893
 Fujin Tea                                279        802      1,081
 Koro Kung Pellets                        278        195        473
 Indi Bourbon                             278      1,042      1,320
 Mukusubii Chitin-os                      277        530        807
 Wheemete Wheat Cakes                     277        212        489
 Arouca Conventual Sweets                 277        963      1,240
 Momus Bog Spaniel                        277      1,476      1,753
 Sanuma Decorative Meat                   275        696        971
 Tanmark Tranquil Tea                     275      1,467      1,742
 Pantaa Prayer Sticks                     275      1,468      1,743
 Zeessze Ant Grub Glue                    274        304        578
 Chateau De Aegaeon                       273      1,025      1,298
 Honesty Pills                            273      1,104      1,377
 Non Euclidian Exotanks                   271        722        993
 Leestian Evil Juice                      271        370        641
 Uszaian Tree Grub                        270        781      1,051
 HIP 10175 Bush Meat                      269      1,702      1,971
 Alya Body Soap                           269        368        637
 Anduliga Fire Works                      267        714        981
 CD-75 Kitten Brand Coffee                266      1,918      2,184
 Gerasian Gueuze Beer                     266        365        631
 Orrerian Vicious Brew                    266        511        777
 Diso Ma Corn                             265        272        537
 Banki Amphibious Leather                 264        507        771
 Baked Greebles                           263        361        624
 Medb Starlube                            263        337        600
 Tiegfries Synth Silk                     263        666        929
 Eshu Umbrellas                           262      1,658      1,920
 Az Cancri Formula 42                     258      5,206      5,464
 Karetii Couture                          250      4,223      4,473
 Crystalline Spheres                      244      4,951      5,195
 Classified Experimental Equipment        239      4,042      4,281
 Kinago Violins                           232      5,883      6,115
 Vidavantian Lace                         214      5,407      5,621
 Giant Verrix                             209      5,271      5,480
 Uzumoku Low-G Wings                      202      6,817      7,019
 Jaques Quinentian Still                  202      6,817      7,019
 The Waters of Shintara                   198      6,663      6,861
 Havasupai Dream Catcher                  153      7,726      7,879
 Ceramic Composites                       137        108        245
 Leather                                  105         91        196
 Synthetic Fabrics                         69         99        168
 Explosives                                66        192        258
 Surface Stabilisers                       38        353        391
 Polymers                                  32         65         97
 Semiconductors                            28        608        636
 Algae                                     22         44         66
 Conductive Fabrics                         9        313        322
 Robotics                                   8      1,222      1,230
 Geological Equipment                       8      1,222      1,230
 Structural Regulators                      8      1,222      1,230
 Building Fabricators                       2      1,499      1,501

(Trade-Dangerous) PS E:\Elite\Trade-Dangerous> python trade.py trade "sol/aham" "orte/vies"
trade.py: System "orte" could match NORTES/, MORTEL/, MORTEN-MARTE/, or REORTE/

(Trade-Dangerous) PS E:\Elite\Trade-Dangerous> python trade.py trade "sol/aham" "reorte/vies" --gpt 8000
 Item                         Profit       Cost     Buying
----------------------------------------------------------
 Monazite                    103,046    121,396    224,442
 Large Survey Data Cache      27,091    199,648    226,739
 Small Survey Data Cache      24,620     16,932     41,552
 Low Temperature Diamonds     17,426     47,202     64,628
 Geological Samples            8,401      4,389     12,790

(Trade-Dangerous) PS E:\Elite\Trade-Dangerous> python trade.py trade "sol/aham" "reorte/vies" --limit 10
 Item                         Profit       Cost     Buying
----------------------------------------------------------
 Monazite                    103,046    121,396    224,442
 Large Survey Data Cache      27,091    199,648    226,739
 Small Survey Data Cache      24,620     16,932     41,552
 Low Temperature Diamonds     17,426     47,202     64,628
 Geological Samples            8,401      4,389     12,790
 Scientific Samples            7,558      3,961     11,519
 Samarium                      6,585     17,579     24,164
 Scientific Research           4,428      9,695     14,123
 Performance Enhancers         2,847      4,749      7,596
 Tritium                       2,319     40,111     42,430

(Trade-Dangerous) PS E:\Elite\Trade-Dangerous> measure-command { python trade.py trade "sol/aham" "reorte/vies" }         

Days              : 0
Hours             : 0
Minutes           : 0
Seconds           : 0
Milliseconds      : 968
Ticks             : 9680140
TotalDays         : 1.12038657407407E-05
TotalHours        : 0.000268892777777778
TotalMinutes      : 0.0161335666666667
TotalSeconds      : 0.968014
TotalMilliseconds : 968.014
```
