### PR TITLE
chore: pythonic cleanup/type hinting/heartbeats

### DIFF
--- a/tradedangerous/commands/trade_cmd.py
+++ b/tradedangerous/commands/trade_cmd.py
@@ -7,7 +7,7 @@ from tradedangerous import TradeORM
 from tradedangerous.db import orm_models as models
 from tradedangerous.formatting import RowFormat, max_len
 
-from sqlalchemy import select, text
+from sqlalchemy import select
 from sqlalchemy.orm import aliased
 
 ######################################################################

--- a/tradedangerous/tradecalc.py
+++ b/tradedangerous/tradecalc.py
@@ -51,7 +51,7 @@ import re
 import sys
 import time
 
-from sqlalchemy import select
+from sqlalchemy import select, text as _sa_text
 
 from .tradeexcept import TradeException
 
@@ -220,8 +220,6 @@ class Route:
 
         Honors TD_NO_COLOR and tdenv.noColor to disable ANSI color codes.
         """
-        import os
-
         # TD_NO_COLOR disables color if set to anything truthy (except 0/false/no/off/"")
         env_val = os.getenv("TD_NO_COLOR", "")
         env_no_color = bool(env_val) and env_val.strip().lower() not in ("0", "", "false", "no", "off")
@@ -535,7 +533,7 @@ class TradeCalc:
             for item in loadItems:
                 ID = item if isinstance(item, int) else item.ID
                 if ID not in avoidItemIDs:
-                    loadIDs.append(ID)
+                    loadIDs += [ID]
             if not loadIDs:
                 raise TradeException("No items to load.")
             itemFilter = loadIDs
@@ -568,23 +566,74 @@ class TradeCalc:
             sys.stdout.flush()
 
         # ---------- Core/Engine path (NO Session; NO ORM entities) ----------
-        columns = (
-            "station_id, item_id, "
-            "demand_price, demand_units, demand_level, "
-            "supply_price, supply_units, supply_level, "
-            "modified"
-        )
+        # kfsone: future wishlist/todo:
+        # Limit the scope of the station probe by identifying systems
+        # worth looking at, we can probably calculate a "bubble" or ask
+        # the user to provide one, and only look at systems inside that
+        # bubble.
+        # 
+        # c.f.
+        # 
+        # command has "from", "ly-per", "empty-ly", hops, jumps, start-jumps, end-jumps.
+        # 
+        # center = (origin.pos_x, origin.pos_y, origin.pos_z)
+        # rounding_buffer = 0.1
+        # buffer = rounding_buffer + empty-ly * (start-hops + end_hops)
+        # max_trade_dist = hops * jumps * ly_per + rounding_buffer
+        # if destination and not via:  # via is not impossible but not doing it here
+        #   destination_dist = destination.get_distance(origin)
+        #   # reset the center to be inbetween the two points
+        #   cx = (origin.pos_x + destination.pos_x) / 2
+        #   cy = (origin.pos_y + destination.pos_y) / 2
+        #   cz = (origin.pos_z + destination.pos_z) / 2
+        #   center = (cx, cy, cz)
+        #   max_trade_dist = max(max_trade_dist, destination_dist)
+        # 
+        # # add a little extra padding (8 ly)
+        # bubble = 8.0 + max_trade_dist + buffer
+        # 
+        # ```
+        # WITH BubbleStation AS (
+        #   SELECT st.station_id,
+        #          (sy.pos_x - :x) * (sy.pos_x - :x) as dx2,
+        #          (sy.pos_y - :y) * (sy.pos_y - :y) as dy2,
+        #          (sy.pos_z - :z) * (sy.pos_z - :z) as dz2
+        #     FROM System sy
+        #          INNER JOIN Station ON st.system_id = sy.system_id
+        #    WHERE (dx2 + dy2 + dz2) < :radius2
+        # )
+        # SELECT si.station_id ...
+        # ...
+        #   JOIN BubbleStation b ON si.station_id = b.station_id
+        # ...
+        # ```
+        # 
+        # this would give us an automatic collapse of the region probed for prices;
+        # might still be quite a few rows, but a heck of a lot less for a lot of
+        # common queries/routes.
 
-        where_clauses = []
+        # Main table is StationItem AS si
+        columns = (
+            "si.station_id, si.item_id, "
+            "si.demand_price, si.demand_units, si.demand_level, "
+            "si.supply_price, si.supply_units, si.supply_level, "
+            "si.modified"
+        )
+        # Dictionary of {"<table> <alias>": (join_type, on condition)
+        # e.g. joins["Station st"] = ("INNER", "st.station_id = si.station_id")
+        joins: dict[str, tuple[str, str]] = {}
+        # any where conditions to add to the query (anded)
+        where_clauses: list[str] = []
+        # key: value such that you can use :key in the query
         params = {}
 
         # Age cutoff (if provided in env)
         if tdenv.maxAge:
             cutoffS = nowS - (tdenv.maxAge * 60 * 60 * 24)
             if tdb.engine.dialect.name == "sqlite":
-                where_clauses.append("CAST(strftime('%s', modified) AS INTEGER) >= :cutoffS")
+                where_clauses.append("CAST(strftime('%s', si.modified) AS INTEGER) >= :cutoffS")
             else:
-                where_clauses.append("UNIX_TIMESTAMP(modified) >= :cutoffS")
+                where_clauses.append("UNIX_TIMESTAMP(si.modified) >= :cutoffS")
             params["cutoffS"] = cutoffS
 
         # Optional item filter — enumerate placeholders (SQLAlchemy text() won't expand tuples)
@@ -594,7 +643,7 @@ class TradeCalc:
                 key = f"iid{i}"
                 params[key] = int(iid)
                 iid_placeholders.append(":" + key)
-            where_clauses.append(f"item_id IN ({', '.join(iid_placeholders)})")
+            where_clauses.append(f"si.item_id IN ({', '.join(iid_placeholders)})")
 
         # Optional station restriction for ultra-light preload
         if self._restrict_station_ids:
@@ -603,13 +652,41 @@ class TradeCalc:
                 key = f"sid{i}"
                 params[key] = int(sid)
                 sid_placeholders.append(":" + key)
-            where_clauses.append(f"station_id IN ({', '.join(sid_placeholders)})")
+            where_clauses.append(f"si.station_id IN ({', '.join(sid_placeholders)})")
 
-        sql = f"SELECT {columns} FROM StationItem"
+        if minDemand > 0:
+            where_clauses.append("si.demand_units > :demand")
+            params["demand"] = minDemand
+        if minSupply > 0:
+            where_clauses.append("si.supply_units > :supply")
+            params["supply"] = minSupply
+
+        join_station = False
+        if tdenv.planetary:
+            where_clauses.append("st.planetary = :planetary")
+            params["planetary"] = tdenv.planetary
+            join_station = True
+        if tdenv.fleet in ['Y', 'N']:
+            comparison = '==' if tdenv.fleet == 'Y' else '!='
+            where_clauses.append(f"st.type_id {comparison} :fleet")
+            params["fleet"] = 24
+            join_station = True
+        if tdenv.odyssey in ['Y', 'N']:
+            comparison = '==' if tdenv.odyssey == 'Y' else '!='
+            where_clauses.append(f"st.type_id {comparison} :odyssey")
+            params["odyssey"] = 25
+        
+        if join_station:
+            joins["Station st"] = "si.station_id = st.station_id"
+
+        sql = f"SELECT {columns} FROM StationItem si"
+        for join_table, join_using in joins.items():
+            sql += f" JOIN {join_table} ON {join_using}"
         if where_clauses:
             sql += " WHERE " + " AND ".join(where_clauses)
 
-        from sqlalchemy import text as _sa_text
+        tdenv.DEBUG1("query: {}", sql)
+        tdenv.DEBUG1("params: {}", params)
         with tdb.engine.connect() as conn:
             result = conn.execute(_sa_text(sql), params)
 
@@ -631,19 +708,17 @@ class TradeCalc:
 
                 # Buying map (demand side)
                 if d_price and d_price > 0:
-                    if not minDemand or (d_units or 0) >= minDemand:
-                        demand[stnID] += [(itmID, d_price, d_units or 0, d_level, ageS)]
-                        dmdCount += 1
+                    demand[stnID] += [(itmID, d_price, d_units or 0, d_level, ageS)]
+                    dmdCount += 1
 
                 # Selling map (supply side)
                 if s_price and s_price > 0 and s_units:
-                    if not minSupply or s_units >= minSupply:
-                        supply[stnID] += [(itmID, s_price, s_units, s_level, ageS)]
-                        supCount += 1
+                    supply[stnID] += [(itmID, s_price, s_units, s_level, ageS)]
+                    supCount += 1
 
-                # Calling 'time.time()' is *very* expensive, so only do it every 256 rows,
+                # Calling 'time.time()' is *very* expensive, so only do it every so many rows
                 # but the == 1 means that we'll do it for the very first row too.
-                if showProgress and (rows_seen & 255) == 1:  # fast modulo 256
+                if showProgress and (rows_seen & 15) == 1:  # fast modulo 16
                     heartbeat()
 
         if showProgress:
@@ -928,7 +1003,7 @@ class TradeCalc:
         tdb = self.tdb
         tdenv = self.tdenv
         avoidPlaces = getattr(tdenv, "avoidPlaces", None) or ()
-        assert not restrictTo or isinstance(restrictTo, set)
+        assert not restrictTo or isinstance(restrictTo, set), f"expected restrictTo to be a set, got: {restrictTo}"
         maxJumpsPer = tdenv.maxJumpsPer
         maxLyPer = tdenv.maxLyPer
         maxPadSize = tdenv.padSize
@@ -1024,9 +1099,10 @@ class TradeCalc:
                     if stn.ID not in buying_ids:
                         continue
                     dests_seen += 1
-                    if heartbeat_enabled and (dests_seen & 31) == 1:    # fast modulo 32
+                    if heartbeat_enabled and (dests_seen & 15) == 1:    # fast modulo 16
                         heartbeat(origin_idx, dests_seen)
                     yield Destination(stnSys, stn, (srcSys, stnSys), srcDist(stnSys))
+                heartbeat(origin_idx, dests_seen)
     
         else:
             getDestinations = tdb.getDestinations
@@ -1045,11 +1121,13 @@ class TradeCalc:
                     fleet=fleet,
                     odyssey=odyssey,
                 ):
+                    if d.station.ID not in buying_ids:
+                        continue
                     dests_seen += 1
-                    if heartbeat_enabled and (dests_seen & 31) == 1:    # fast modulo 32
+                    if heartbeat_enabled and (dests_seen & 15) == 1:    # fast modulo 16
                         heartbeat(origin_idx, dests_seen)
-                    if d.station.ID in buying_ids:
-                        yield d
+                    yield d
+                heartbeat(origin_idx, dests_seen)
     
         connections = 0
         getSelling = self.stationsSelling.get

--- a/tradedangerous/tradeenv.py
+++ b/tradedangerous/tradeenv.py
@@ -18,7 +18,7 @@ from rich.traceback import install as install_rich_traces
 
 if typing.TYPE_CHECKING:
     import argparse
-    from typing import Any, Optional, Union
+    from typing import Any
 
 
 _ROOT = os.path.abspath(os.path.dirname(__file__))
@@ -44,10 +44,10 @@ class BaseColorTheme:
     # blink:    NEVER = "don't you dare"
     
     # style, label
-    debug, DEBUG    = dim,  "#"
-    note,  NOTE     = bold, "NOTE"
-    info,  INFO     = "",   "INFO"
-    warn,  WARNING  = "",   "WARNING"
+    debug, DEBUG = dim,  "#"
+    note,  NOTE  = bold, "NOTE"
+    info,  INFO  = "",   "INFO"
+    warn,  WARN  = "",   "WARNING"
     
     seq_first:  str = ""        # the first item in a sequence
     seq_last:   str = ""        # the last item in a sequence
@@ -72,10 +72,10 @@ class BasicRichColorTheme(BaseColorTheme):
     italic    = "[italic]"
     
     # style, label
-    debug, DEBUG   = dim,  "#"
-    note,  NOTE    = bold, "NOTE"
-    info,  INFO    = "",   "INFO"
-    warn,  WARNING = "[orange3]", "WARNING"
+    debug, DEBUG = dim,  "#"
+    note,  NOTE  = bold, "NOTE"
+    info,  INFO  = "",   "INFO"
+    warn,  WARN  = "[orange3]", "WARNING"
     
     def render(self, renderable: Any, style: str) -> str:  # pragma: no cover
         style_attr = getattr(self, style, "")
@@ -88,7 +88,7 @@ class RichColorTheme(BasicRichColorTheme):
     """ Demonstrates how you might augment the rich theme with colors to be used fin e.g tradecal. """
     DEBUG = ":spider_web:"
     NOTE  = ":information_source:"
-    WARNING = ":warning:"
+    WARN  = ":warning:"
     INFO  = ":gear:"
     
     # e.g. First station
@@ -107,9 +107,9 @@ class BaseConsoleIOMixin:
     console: Console
     stderr:  Console
     theme:   BaseColorTheme
-    quiet:   bool
+    quiet:   int
     
-    def uprint(self, *args, stderr: bool = False, style: str = None, **kwargs) -> None:
+    def uprint(self, *args: Any, stderr: bool = False, style: str | None = None, **kwargs: Any) -> None:
         """
             unicode-safe print via console or stderr, with 'rich' markup handling.
         """
@@ -119,7 +119,7 @@ class BaseConsoleIOMixin:
 
 class NonUtf8ConsoleIOMixin(BaseConsoleIOMixin):
     """ Mixing for running output through rich with UTF8-translation smoothing. """
-    def uprint(self, *args, stderr: bool = False, style: str = None, **kwargs) -> None:
+    def uprint(self, *args: Any, stderr: bool = False, style: str | None = None, **kwargs: Any) -> None:
         """ unicode-handling print: when the stdout stream is not utf-8 supporting,
             we do a little extra io work to ensure users don't get confusing unicode
             errors. When the output stream *is* utf-8.
@@ -155,12 +155,6 @@ class NonUtf8ConsoleIOMixin(BaseConsoleIOMixin):
             console.print(*components, style=style, **kwargs)
 
 
-# If the console doesn't support UTF8, use the more-complicated implementation.
-if str(sys.stdout.encoding).upper() != 'UTF-8':
-    Utf8SafeConsoleIOMixin = NonUtf8ConsoleIOMixin
-else:
-    Utf8SafeConsoleIOMixin = BaseConsoleIOMixin
-
 ENV_DEFAULTS: dict[str, Any] = {
         'debug': 0,
         'detail': 0,
@@ -176,6 +170,13 @@ ENV_DEFAULTS: dict[str, Any] = {
         'console': CONSOLE,
         'stderr':  STDERR,
     }
+
+
+# If the console doesn't support UTF8, use the more-complicated implementation.
+if str(sys.stdout.encoding).upper() != 'UTF-8':
+    Utf8SafeConsoleIOMixin = NonUtf8ConsoleIOMixin
+else:
+    Utf8SafeConsoleIOMixin = BaseConsoleIOMixin
 
 
 class TradeEnv(Utf8SafeConsoleIOMixin):
@@ -197,16 +198,19 @@ class TradeEnv(Utf8SafeConsoleIOMixin):
     debug: int
     detail: int
     color: bool
+    theme: BaseColorTheme
     persist: bool
     dataDir: str
     csvDir: str
     tmpDir: str
     templateDir: str
     cwDir: str
+    console: Console
+    stderr: Console
     
     encoding = sys.stdout.encoding
     
-    def __init__(self, properties: dict[str, typing.Any] | argparse.Namespace | None = None, **kwargs) -> None:
+    def __init__(self, properties: dict[str, typing.Any] | argparse.Namespace | None = None, **kwargs: Any) -> None:
         # Inject the defaults into ourselves in a dict-like way
         self.__dict__.update(ENV_DEFAULTS)
         
@@ -227,7 +231,7 @@ class TradeEnv(Utf8SafeConsoleIOMixin):
         self.theme = RichColorTheme() if self.__dict__['color'] else BasicRichColorTheme()
 
     @staticmethod
-    def __disabled_uprint(*args, **kwargs) -> None:
+    def __disabled_uprint(*args: Any, **kwargs: Any) -> None:
         pass
 
     def __getattr__(self, key: str) -> Any:
@@ -240,17 +244,19 @@ class TradeEnv(Utf8SafeConsoleIOMixin):
             case "WARN" if self.quiet > 1:
                 disabled = True
             case "WARN":
-                theme_prefix, theme_label = self.theme.warn, self.theme.WARNING
+                theme_prefix, theme_label = self.theme.warn, self.theme.WARN
             case "NOTE" | "INFO" if self.quiet:
                 disabled = True
             case "NOTE":
                 theme_prefix, theme_label = self.theme.note, self.theme.NOTE
             case "INFO":
                 theme_prefix, theme_label = self.theme.info, self.theme.INFO
-            case _ if key.startswith("DEBUG") and self.debug <= int(key[5:]):
+            case _ if key.startswith("DEBUG") and int(key[5:]) >= self.debug:
                 disabled = True
             case _ if key.startswith("DEBUG"):
-                theme_prefix, theme_label = self.theme.debug, self.theme.DEBUG
+                theme_prefix, theme_label = self.theme.debug, self.theme.DEBUG + key[5:]
+            case _:
+                pass
 
         # If there's no function but there's a theme, create a function
         if disabled:
@@ -258,10 +264,10 @@ class TradeEnv(Utf8SafeConsoleIOMixin):
             return self.__disabled_uprint
 
         if theme_prefix is not None:
-            def __log_helper(outText, *args, stderr: bool = False, **kwargs):
+            def __log_helper(outText: str, *args: Any, stderr: bool = False, **kwargs: Any):
                 try:
                     msg = str(outText) if not (args or kwargs) else str(outText).format(*args, **kwargs)
-                except Exception:  # noqa  # bare exception
+                except Exception:  # noqa  # pylint: disable=broad-except
                     # Fallback: dump raw message + args/kwargs repr
                     msg = f"{outText} {args!r} {kwargs!r}"
                 
@@ -272,7 +278,7 @@ class TradeEnv(Utf8SafeConsoleIOMixin):
         
         return None
     
-    def remove_file(self, *args) -> bool:
+    def remove_file(self, *args: str | Path) -> bool:
         """ Unlinks a file, as long as it exists, and logs the action at level 1. """
         path = Path(*args)
         if not path.exists():
@@ -281,7 +287,7 @@ class TradeEnv(Utf8SafeConsoleIOMixin):
         self.DEBUG1(":cross_mark: deleted {}", path)
         return True
     
-    def rename_file(self, *, old: os.PathLike, new: os.PathLike) -> bool:
+    def rename_file(self, *, old: str | Path, new: str | Path) -> bool:
         """
         If 'new' exists, deletes it, and then attempts to rename old -> new. If new is not specified,
         then '.old' is appended to the end of the old filename while retaining the original suffix.

--- a/tradedangerous/tradeenv.pyi
+++ b/tradedangerous/tradeenv.pyi
@@ -1,0 +1,110 @@
+# pylint: disable=multiple-statements-on-one-line
+# flake8: noqa: E704
+# 
+# Because TradeEnv on-the-fly constructs the various logging methods
+# etc, most IDEs and linters struggle with the types of many of its
+# methods and built-in properties.
+#
+# This is a python header unit that forward declares stuff so that
+# the IDEs are less of a wall of squiggles.
+
+from pathlib import Path
+from typing import Any
+from rich.console import Console
+
+
+class BaseColorTheme:
+    CLOSE: str
+    dim: str
+    bold: str
+    italic: str
+    debug: str
+    DEBUG: str
+    note: str
+    NOTE: str
+    info: str
+    INFO: str
+    warn: str
+    WARN: str
+    seq_first: str
+    seq_last: str
+    itm_units: str
+    itm_name: str
+    itm_price: str
+    def render(self, renderable: Any, style: str) -> str: ...
+
+
+class BasicRichColorTheme(BaseColorTheme):
+    CLOSE: str
+    bold: str
+    dim: str
+    italic: str
+    debug: str
+    DEBUG: str
+    note: str
+    NOTE: str
+    info: str
+    INFO: str
+    warn: str
+    WARN: str
+    def render(self, renderable: Any, style: str) -> str: ...
+
+
+class RichColorTheme(BasicRichColorTheme):
+    DEBUG: str
+    NOTE: str
+    WARN: str
+    INFO: str
+    seq_first: str
+    seq_last: str
+    itm_units: str
+    itm_name: str
+    itm_price: str
+
+
+class BaseConsoleIOMixin:
+    console: Console
+    stderr: Console
+    theme: BaseColorTheme
+    quiet: int
+    def uprint(self, *args: Any, stderr: bool = False, style: str | None = None, **kwargs: Any) -> None: ...
+
+
+class NonUtf8ConsoleIOMixin(BaseConsoleIOMixin):
+    def uprint(self, *args: Any, stderr: bool = False, style: str | None = None, **kwargs: Any) -> None: ...
+
+
+class TradeEnv(BaseConsoleIOMixin):
+    debug: int
+    detail: int
+    color: bool
+    theme: BaseColorTheme
+    persist: bool
+    dataDir: str
+    csvDir: str
+    tmpDir: str
+    templateDir: str
+    cwDir: str
+    console: Console
+    stderr: Console
+    quiet: int
+    
+    encoding: str
+    
+    def __init__(self, properties: dict[str, Any] | None = None, **kwargs: Any) -> None: ...
+    
+    # Dynamically-generated log methods with full type hints
+    def DEBUG0(self, outText: str, *args: Any, stderr: bool = False, **kwargs: Any) -> None: ...
+    def DEBUG1(self, outText: str, *args: Any, stderr: bool = False, **kwargs: Any) -> None: ...
+    def DEBUG2(self, outText: str, *args: Any, stderr: bool = False, **kwargs: Any) -> None: ...
+    def DEBUG3(self, outText: str, *args: Any, stderr: bool = False, **kwargs: Any) -> None: ...
+    def DEBUG4(self, outText: str, *args: Any, stderr: bool = False, **kwargs: Any) -> None: ...
+    def INFO(self, outText: str, *args: Any, stderr: bool = False, **kwargs: Any) -> None: ...
+    def NOTE(self, outText: str, *args: Any, stderr: bool = False, **kwargs: Any) -> None: ...
+    def WARN(self, outText: str, *args: Any, stderr: bool = False, **kwargs: Any) -> None: ...
+    
+    # File operations
+    def remove_file(self, *args: str | Path) -> bool: ...
+    def rename_file(self, *, old: str | Path, new: str | Path) -> bool: ...
+    
+    def uprint(self, *args: Any, stderr: bool = False, style: str | None = None, **kwargs: Any) -> None: ...


### PR DESCRIPTION
chore: pythonic cleanup/type hinting/heartbeats
chore: reduce IDE squiggles by providing type hints for TradeEnv (tradeenv.pyi) chore: replace some hot-path calls to .append in lieu of += []
- the regression that made .append faster is resolved in 3.10 and the delta is more pronounced in newer pythons,
- did not touch cases where we have to call .append due to python scope resolution rules, chore: remove some unused imports and moved some inline imports to top-of-file; lazy importing is usually a smell chore: hoist invariant conditions out of path_iter in get destinations (why execute the same 'if' for every row) chore: consistency/hinting pass on TradeEnv

Note: This is a separation of concerns for PR#246 https://github.com/eyeonus/Trade-Dangerous/pull/246 so I can treat the larger TradeCalc refactor separately.