### PR TITLE
chore: pythonic cleanup/type hinting/heartbeats

### DIFF
--- a/tradedangerous/commands/trade_cmd.py
+++ b/tradedangerous/commands/trade_cmd.py
@@ -7,7 +7,7 @@ from tradedangerous import TradeORM
 from tradedangerous.db import orm_models as models
 from tradedangerous.formatting import RowFormat, max_len
 
-from sqlalchemy import select, text
+from sqlalchemy import select
 from sqlalchemy.orm import aliased
 
 ######################################################################

--- a/tradedangerous/tradecalc.py
+++ b/tradedangerous/tradecalc.py
@@ -51,7 +51,7 @@ import re
 import sys
 import time
 
-from sqlalchemy import select
+from sqlalchemy import select, text as _sa_text
 
 from .tradeexcept import TradeException
 
@@ -220,8 +220,6 @@ class Route:
 
         Honors TD_NO_COLOR and tdenv.noColor to disable ANSI color codes.
         """
-        import os
-
         # TD_NO_COLOR disables color if set to anything truthy (except 0/false/no/off/"")
         env_val = os.getenv("TD_NO_COLOR", "")
         env_no_color = bool(env_val) and env_val.strip().lower() not in ("0", "", "false", "no", "off")
@@ -609,7 +607,8 @@ class TradeCalc:
         if where_clauses:
             sql += " WHERE " + " AND ".join(where_clauses)
 
-        from sqlalchemy import text as _sa_text
+        tdenv.DEBUG1("query: {}", sql)
+        tdenv.DEBUG1("params: {}", params)
         with tdb.engine.connect() as conn:
             result = conn.execute(_sa_text(sql), params)
 
@@ -632,18 +631,18 @@ class TradeCalc:
                 # Buying map (demand side)
                 if d_price and d_price > 0:
                     if not minDemand or (d_units or 0) >= minDemand:
-                        demand[stnID] += [(itmID, d_price, d_units or 0, d_level, ageS)]
+                        demand[stnID].append((itmID, d_price, d_units or 0, d_level, ageS))
                         dmdCount += 1
 
                 # Selling map (supply side)
                 if s_price and s_price > 0 and s_units:
                     if not minSupply or s_units >= minSupply:
-                        supply[stnID] += [(itmID, s_price, s_units, s_level, ageS)]
+                        supply[stnID].append((itmID, s_price, s_units, s_level, ageS))
                         supCount += 1
 
-                # Calling 'time.time()' is *very* expensive, so only do it every 256 rows,
+                # Calling 'time.time()' is *very* expensive, so only do it every so many rows
                 # but the == 1 means that we'll do it for the very first row too.
-                if showProgress and (rows_seen & 255) == 1:  # fast modulo 256
+                if showProgress and (rows_seen & 15) == 1:  # fast modulo 16
                     heartbeat()
 
         if showProgress:
@@ -1024,9 +1023,11 @@ class TradeCalc:
                     if stn.ID not in buying_ids:
                         continue
                     dests_seen += 1
-                    if heartbeat_enabled and (dests_seen & 31) == 1:    # fast modulo 32
+                    if heartbeat_enabled and (dests_seen & 15) == 1:    # fast modulo 16
                         heartbeat(origin_idx, dests_seen)
                     yield Destination(stnSys, stn, (srcSys, stnSys), srcDist(stnSys))
+                if heartbeat_enabled:
+                    heartbeat(origin_idx, dests_seen)
     
         else:
             getDestinations = tdb.getDestinations
@@ -1045,11 +1046,14 @@ class TradeCalc:
                     fleet=fleet,
                     odyssey=odyssey,
                 ):
+                    if d.station.ID not in buying_ids:
+                        continue
                     dests_seen += 1
-                    if heartbeat_enabled and (dests_seen & 31) == 1:    # fast modulo 32
+                    if heartbeat_enabled and (dests_seen & 15) == 1:    # fast modulo 16
                         heartbeat(origin_idx, dests_seen)
-                    if d.station.ID in buying_ids:
-                        yield d
+                    yield d
+                if heartbeat_enabled:
+                    heartbeat(origin_idx, dests_seen)
     
         connections = 0
         getSelling = self.stationsSelling.get
@@ -1205,7 +1209,7 @@ class TradeCalc:
                 # update hop-global best score (nearest int)
                 try:
                     si = int(round(score))
-                except Exception:
+                except TypeError:
                     si = int(score)
                 if si > best_seen_score:
                     best_seen_score = si
@@ -1242,9 +1246,7 @@ class TradeCalc:
         if connections == 0:
             raise NoHopsError("No destinations could be reached within the constraints.")
     
-        result = []
-        for (dst, route, trade, jumps, _, score) in bestToDest.values():
-            result.append(route.plus(dst, trade, jumps, score))
-    
-        return result
-    
+        return [
+            route.plus(dst, trade, jumps, score)
+            for (dst, route, trade, jumps, _, score) in bestToDest.values()
+        ]

--- a/tradedangerous/tradedb.py
+++ b/tradedangerous/tradedb.py
@@ -2141,18 +2141,24 @@ class TradeDB:
                     for station in node.system.stations:
                         yield node, station
         
+        fleet = fleet or "YN?"
+        maxPadSize = maxPadSize or "SML?"
+        odyssey = odyssey or "YN?"
+        planetary = "N" if noPlanet else (planetary or "YN?")
+        
         path_iter = iter(
           (node, station) for (node, station) in path_iter_fn()
-          if (station.planetary == 'N' if noPlanet else True) and
-            (station not in avoidPlaces if avoidPlaces else True) and
-            (station.checkPadSize(maxPadSize) if maxPadSize else True) and
-            (station.checkPlanetary(planetary) if planetary else True) and
-            (station.checkFleet(fleet) if fleet else True) and
-            (station.checkOdyssey(odyssey) if odyssey else True) and
-            (station.lsFromStar > 0 and station.lsFromStar <= maxLsFromStar if maxLsFromStar else True)
+          if station.planetary in planetary and
+            station not in avoidPlaces and
+            station.maxPadSize in maxPadSize and
+            station.fleet in fleet and
+            station.odyssey in odyssey and
+            (not maxLsFromStar or 0 < station.lsFromStar <= maxLsFromStar)
         )
-        for node, stn in path_iter:
-            yield Destination(node.system, stn, node.via, node.distLy)
+        yield from (
+            Destination(node.system, stn, node.via, node.distLy)
+            for node, stn in path_iter
+        )
     
     ############################################################
     # Ship data.

--- a/tradedangerous/tradeenv.py
+++ b/tradedangerous/tradeenv.py
@@ -18,7 +18,7 @@ from rich.traceback import install as install_rich_traces
 
 if typing.TYPE_CHECKING:
     import argparse
-    from typing import Any, Optional, Union
+    from typing import Any
 
 
 _ROOT = os.path.abspath(os.path.dirname(__file__))
@@ -44,10 +44,10 @@ class BaseColorTheme:
     # blink:    NEVER = "don't you dare"
     
     # style, label
-    debug, DEBUG    = dim,  "#"
-    note,  NOTE     = bold, "NOTE"
-    info,  INFO     = "",   "INFO"
-    warn,  WARNING  = "",   "WARNING"
+    debug, DEBUG = dim,  "#"
+    note,  NOTE  = bold, "NOTE"
+    info,  INFO  = "",   "INFO"
+    warn,  WARN  = "",   "WARNING"
     
     seq_first:  str = ""        # the first item in a sequence
     seq_last:   str = ""        # the last item in a sequence
@@ -72,10 +72,10 @@ class BasicRichColorTheme(BaseColorTheme):
     italic    = "[italic]"
     
     # style, label
-    debug, DEBUG   = dim,  "#"
-    note,  NOTE    = bold, "NOTE"
-    info,  INFO    = "",   "INFO"
-    warn,  WARNING = "[orange3]", "WARNING"
+    debug, DEBUG = dim,  "#"
+    note,  NOTE  = bold, "NOTE"
+    info,  INFO  = "",   "INFO"
+    warn,  WARN  = "[orange3]", "WARNING"
     
     def render(self, renderable: Any, style: str) -> str:  # pragma: no cover
         style_attr = getattr(self, style, "")
@@ -88,7 +88,7 @@ class RichColorTheme(BasicRichColorTheme):
     """ Demonstrates how you might augment the rich theme with colors to be used fin e.g tradecal. """
     DEBUG = ":spider_web:"
     NOTE  = ":information_source:"
-    WARNING = ":warning:"
+    WARN  = ":warning:"
     INFO  = ":gear:"
     
     # e.g. First station
@@ -107,9 +107,9 @@ class BaseConsoleIOMixin:
     console: Console
     stderr:  Console
     theme:   BaseColorTheme
-    quiet:   bool
+    quiet:   int
     
-    def uprint(self, *args, stderr: bool = False, style: str = None, **kwargs) -> None:
+    def uprint(self, *args: Any, stderr: bool = False, style: str | None = None, **kwargs: Any) -> None:
         """
             unicode-safe print via console or stderr, with 'rich' markup handling.
         """
@@ -119,7 +119,7 @@ class BaseConsoleIOMixin:
 
 class NonUtf8ConsoleIOMixin(BaseConsoleIOMixin):
     """ Mixing for running output through rich with UTF8-translation smoothing. """
-    def uprint(self, *args, stderr: bool = False, style: str = None, **kwargs) -> None:
+    def uprint(self, *args: Any, stderr: bool = False, style: str | None = None, **kwargs: Any) -> None:
         """ unicode-handling print: when the stdout stream is not utf-8 supporting,
             we do a little extra io work to ensure users don't get confusing unicode
             errors. When the output stream *is* utf-8.
@@ -155,12 +155,6 @@ class NonUtf8ConsoleIOMixin(BaseConsoleIOMixin):
             console.print(*components, style=style, **kwargs)
 
 
-# If the console doesn't support UTF8, use the more-complicated implementation.
-if str(sys.stdout.encoding).upper() != 'UTF-8':
-    Utf8SafeConsoleIOMixin = NonUtf8ConsoleIOMixin
-else:
-    Utf8SafeConsoleIOMixin = BaseConsoleIOMixin
-
 ENV_DEFAULTS: dict[str, Any] = {
         'debug': 0,
         'detail': 0,
@@ -176,6 +170,13 @@ ENV_DEFAULTS: dict[str, Any] = {
         'console': CONSOLE,
         'stderr':  STDERR,
     }
+
+
+# If the console doesn't support UTF8, use the more-complicated implementation.
+if str(sys.stdout.encoding).upper() != 'UTF-8':
+    Utf8SafeConsoleIOMixin = NonUtf8ConsoleIOMixin
+else:
+    Utf8SafeConsoleIOMixin = BaseConsoleIOMixin
 
 
 class TradeEnv(Utf8SafeConsoleIOMixin):
@@ -197,16 +198,19 @@ class TradeEnv(Utf8SafeConsoleIOMixin):
     debug: int
     detail: int
     color: bool
+    theme: BaseColorTheme
     persist: bool
     dataDir: str
     csvDir: str
     tmpDir: str
     templateDir: str
     cwDir: str
+    console: Console
+    stderr: Console
     
     encoding = sys.stdout.encoding
     
-    def __init__(self, properties: dict[str, typing.Any] | argparse.Namespace | None = None, **kwargs) -> None:
+    def __init__(self, properties: dict[str, typing.Any] | argparse.Namespace | None = None, **kwargs: Any) -> None:
         # Inject the defaults into ourselves in a dict-like way
         self.__dict__.update(ENV_DEFAULTS)
         
@@ -227,7 +231,7 @@ class TradeEnv(Utf8SafeConsoleIOMixin):
         self.theme = RichColorTheme() if self.__dict__['color'] else BasicRichColorTheme()
 
     @staticmethod
-    def __disabled_uprint(*args, **kwargs) -> None:
+    def __disabled_uprint(*args: Any, **kwargs: Any) -> None:
         pass
 
     def __getattr__(self, key: str) -> Any:
@@ -240,17 +244,19 @@ class TradeEnv(Utf8SafeConsoleIOMixin):
             case "WARN" if self.quiet > 1:
                 disabled = True
             case "WARN":
-                theme_prefix, theme_label = self.theme.warn, self.theme.WARNING
+                theme_prefix, theme_label = self.theme.warn, self.theme.WARN
             case "NOTE" | "INFO" if self.quiet:
                 disabled = True
             case "NOTE":
                 theme_prefix, theme_label = self.theme.note, self.theme.NOTE
             case "INFO":
                 theme_prefix, theme_label = self.theme.info, self.theme.INFO
-            case _ if key.startswith("DEBUG") and self.debug <= int(key[5:]):
+            case _ if key.startswith("DEBUG") and int(key[5:]) >= self.debug:
                 disabled = True
             case _ if key.startswith("DEBUG"):
-                theme_prefix, theme_label = self.theme.debug, self.theme.DEBUG
+                theme_prefix, theme_label = self.theme.debug, self.theme.DEBUG + key[5:]
+            case _:
+                pass
 
         # If there's no function but there's a theme, create a function
         if disabled:
@@ -258,10 +264,10 @@ class TradeEnv(Utf8SafeConsoleIOMixin):
             return self.__disabled_uprint
 
         if theme_prefix is not None:
-            def __log_helper(outText, *args, stderr: bool = False, **kwargs):
+            def __log_helper(outText: str, *args: Any, stderr: bool = False, **kwargs: Any):
                 try:
                     msg = str(outText) if not (args or kwargs) else str(outText).format(*args, **kwargs)
-                except Exception:  # noqa  # bare exception
+                except Exception:  # noqa  # pylint: disable=broad-except
                     # Fallback: dump raw message + args/kwargs repr
                     msg = f"{outText} {args!r} {kwargs!r}"
                 
@@ -272,7 +278,7 @@ class TradeEnv(Utf8SafeConsoleIOMixin):
         
         return None
     
-    def remove_file(self, *args) -> bool:
+    def remove_file(self, *args: str | Path) -> bool:
         """ Unlinks a file, as long as it exists, and logs the action at level 1. """
         path = Path(*args)
         if not path.exists():
@@ -281,7 +287,7 @@ class TradeEnv(Utf8SafeConsoleIOMixin):
         self.DEBUG1(":cross_mark: deleted {}", path)
         return True
     
-    def rename_file(self, *, old: os.PathLike, new: os.PathLike) -> bool:
+    def rename_file(self, *, old: str | Path, new: str | Path) -> bool:
         """
         If 'new' exists, deletes it, and then attempts to rename old -> new. If new is not specified,
         then '.old' is appended to the end of the old filename while retaining the original suffix.

--- a/tradedangerous/tradeenv.pyi
+++ b/tradedangerous/tradeenv.pyi
@@ -1,0 +1,111 @@
+# pylint: disable=multiple-statements-on-one-line
+# flake8: noqa: E704
+# 
+# Because TradeEnv on-the-fly constructs the various logging methods
+# etc, most IDEs and linters struggle with the types of many of its
+# methods and built-in properties.
+#
+# This is a python header unit that forward declares stuff so that
+# the IDEs are less of a wall of squiggles.
+
+from pathlib import Path
+from typing import Any
+from rich.console import Console
+import argparse
+
+
+class BaseColorTheme:
+    CLOSE: str
+    dim: str
+    bold: str
+    italic: str
+    debug: str
+    DEBUG: str
+    note: str
+    NOTE: str
+    info: str
+    INFO: str
+    warn: str
+    WARN: str
+    seq_first: str
+    seq_last: str
+    itm_units: str
+    itm_name: str
+    itm_price: str
+    def render(self, renderable: Any, style: str) -> str: ...
+
+
+class BasicRichColorTheme(BaseColorTheme):
+    CLOSE: str
+    bold: str
+    dim: str
+    italic: str
+    debug: str
+    DEBUG: str
+    note: str
+    NOTE: str
+    info: str
+    INFO: str
+    warn: str
+    WARN: str
+    def render(self, renderable: Any, style: str) -> str: ...
+
+
+class RichColorTheme(BasicRichColorTheme):
+    DEBUG: str
+    NOTE: str
+    WARN: str
+    INFO: str
+    seq_first: str
+    seq_last: str
+    itm_units: str
+    itm_name: str
+    itm_price: str
+
+
+class BaseConsoleIOMixin:
+    console: Console
+    stderr: Console
+    theme: BaseColorTheme
+    quiet: int
+    def uprint(self, *args: Any, stderr: bool = False, style: str | None = None, **kwargs: Any) -> None: ...
+
+
+class NonUtf8ConsoleIOMixin(BaseConsoleIOMixin):
+    def uprint(self, *args: Any, stderr: bool = False, style: str | None = None, **kwargs: Any) -> None: ...
+
+
+class TradeEnv(BaseConsoleIOMixin):
+    debug: int
+    detail: int
+    color: bool
+    theme: BaseColorTheme
+    persist: bool
+    dataDir: str
+    csvDir: str
+    tmpDir: str
+    templateDir: str
+    cwDir: str
+    console: Console
+    stderr: Console
+    quiet: int
+    
+    encoding: str
+    
+    def __init__(self, properties: dict[str, Any] | argparse.Namespace | None = None, **kwargs: Any) -> None: ...
+    
+    # Dynamically-generated log methods with full type hints
+    def DEBUG0(self, outText: str, *args: Any, stderr: bool = False, **kwargs: Any) -> None: ...
+    def DEBUG1(self, outText: str, *args: Any, stderr: bool = False, **kwargs: Any) -> None: ...
+    def DEBUG2(self, outText: str, *args: Any, stderr: bool = False, **kwargs: Any) -> None: ...
+    def DEBUG3(self, outText: str, *args: Any, stderr: bool = False, **kwargs: Any) -> None: ...
+    def DEBUG4(self, outText: str, *args: Any, stderr: bool = False, **kwargs: Any) -> None: ...
+    def INFO(self, outText: str, *args: Any, stderr: bool = False, **kwargs: Any) -> None: ...
+    def NOTE(self, outText: str, *args: Any, stderr: bool = False, **kwargs: Any) -> None: ...
+    def WARN(self, outText: str, *args: Any, stderr: bool = False, **kwargs: Any) -> None: ...
+    
+    # File operations
+    def remove_file(self, *args: str | Path) -> bool: ...
+    def rename_file(self, *, old: str | Path, new: str | Path) -> bool: ...
+    
+    def uprint(self, *args: Any, stderr: bool = False, style: str | None = None, **kwargs: Any) -> None: ...


### PR DESCRIPTION
chore: reduce IDE squiggles by providing type hints for TradeEnv (tradeenv.pyi) chore: replace some hot-path calls to .append in lieu of += []
- the regression that made .append faster is resolved in 3.10 and the delta is more pronounced in newer pythons,
- did not touch cases where we have to call .append due to python scope resolution rules,

chore: remove some unused imports and moved some inline imports to top-of-file; lazy importing is usually a smell

chore: hoist invariant conditions out of path_iter in get destinations (why execute the same 'if' for every row)

chore: consistency/hinting pass on TradeEnv

This is a separation of concerns of pr #246 to isolate the larger tradedb changes.

Validation:
<img width="1124" height="315" alt="image" src="https://github.com/user-attachments/assets/33c36a77-d1fa-4a8e-9f36-067af0afc918" />

Also I finally unstuck my "autocrlf" setting for the repository and turned on "show whitespace" in sourcetree ;)
