### PR TITLE
feat: Network log/Journal reading module tradegame.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ rich==13.7.1
 importlib-metadata>=1
 SQLAlchemy>=2.0,<3.0
 ijson>=3.1
+orjson>=3.11.5

--- a/tox.ini
+++ b/tox.ini
@@ -177,7 +177,8 @@ commands =
 		tradedangerous/version.py \
 		tradedangerous/misc/progress.py \
 		tradedangerous/plugins/eddblink_plug.py \
-		tradedangerous/plugins/spansh_plug.py
+		tradedangerous/plugins/spansh_plug.py \
+		tradedangerous/plugins/journal_plug.py
 
 [pytest]
 markers =

--- a/tradedangerous/commands/exceptions.py
+++ b/tradedangerous/commands/exceptions.py
@@ -50,7 +50,7 @@ For more help, see the TradeDangerous Wiki:
     https://github.com/eyeonus/Trade-Dangerous/wiki
 """
 
-class GameDataError(TradeException)
+class GameDataError(TradeException):
     """
         Raised when imported or journal data is internally inconsistent
         or clearly invalid (e.g. cargo load exceeds cargo capacity).

--- a/tradedangerous/commands/exceptions.py
+++ b/tradedangerous/commands/exceptions.py
@@ -50,6 +50,31 @@ For more help, see the TradeDangerous Wiki:
     https://github.com/eyeonus/Trade-Dangerous/wiki
 """
 
+class GameDataError(TradeException)
+    """
+        Raised when imported or journal data is internally inconsistent
+        or clearly invalid (e.g. cargo load exceeds cargo capacity).
+
+        Attributes:
+            errorStr    A short description of the inconsistency.
+    """
+    def __init__(self, errorStr):
+        self.errorStr = errorStr
+
+    def __str__(self):
+        return f"""Error: {self.errorStr}
+Possible causes:
+- The journal data was incomplete or out of sync when read,
+- You recently changed ships or game state and journals are still updating,
+- The wrong journals or save files are being read (check your journal path),
+- Or the data on disk has been corrupted.
+
+Try again after the game has fully updated, or re-run the command with
+--full-load to ignore current cargo occupancy if appropriate.
+
+For more help, see the TradeDangerous Wiki:
+    https://github.com/eyeonus/Trade-Dangerous/wiki
+"""
 
 class PadSizeError(CommandLineError):
     """ Raised when an invalid pad-size option is given. """

--- a/tradedangerous/commands/trade_cmd.py
+++ b/tradedangerous/commands/trade_cmd.py
@@ -266,6 +266,10 @@ def run(results: CommandResults, cmdenv: CommandEnv, tdb: TradeORM | None) -> Co
         # If they're doing --load but not --want_load, deduct the cargo occupancy
         if want_load and not full_load:
             cargo_space -= max(status.cargo_load, 0)
+            if cargo_space < 0:
+                raise GameDataError(
+                    "Game data is inconsistent (cargo load exceeds cargo capacity)."
+                )
             if cargo_space == 0:
                 raise CommandLineError("Cargo hold is full: use --full-load if you want to ignore current cargo occupancy")
         results.summary.cargo_space = max(cargo_space, 1)  # clamp to >= 1

--- a/tradedangerous/commands/trade_cmd.py
+++ b/tradedangerous/commands/trade_cmd.py
@@ -1,15 +1,22 @@
 # tradedangerous/commands/trade_cmd.py
+from __future__ import annotations
 import datetime
+import typing
 
 from .commandenv import ResultRow
-from .exceptions import CommandLineError
-from .parsing import ParseArgument
-from tradedangerous import TradeORM
+from .exceptions import CommandLineError, NoDataError
+from .parsing import ParseArgument, MutuallyExclusiveGroup
+from tradedangerous import TradeException, TradeORM
 from tradedangerous.db import orm_models as models
+from tradedangerous.tradegame import EliteGame, JsonFiles, require_game_data
 from tradedangerous.formatting import RowFormat, max_len
 
 from sqlalchemy import select
 from sqlalchemy.orm import aliased
+
+
+if typing.TYPE_CHECKING:
+    from .commandenv import CommandEnv, CommandResults
 
 
 ######################################################################
@@ -39,10 +46,38 @@ switches = [
         default = 1,
     ),
     ParseArgument('--limit', '-n',
-        help = 'Limit output to the top N results',
+        help = 'Limit output to the first N results',
         dest = 'limit',
         type = int,
         default = 0,
+    ),
+    MutuallyExclusiveGroup(
+        ParseArgument('--fill', '-f',
+            help = "Reports the maximum profit based on supply vs your current ship's cargo capacity.",
+            action = 'store_true',
+        ),
+        ParseArgument('--load',
+            help = "Lists only the trades needed to fill your current ship's current free cargo space (see --full-load).",
+            action = 'store_true',
+        ),
+        ParseArgument('--full-load',
+            help = "Lists only the trades needed to fill your current ship's cargo hold from scratch.",
+            action = 'store_true',
+        ),
+    ),
+    ParseArgument('--supply', '-S',
+        help = 'Requires at least this many units available at the seller (default 1)',
+        type = int,
+        default = 1,
+    ),
+    ParseArgument('--reverse', '-R',
+        help = "Show the reverse trade: swaps origin and dest. This is a convenience for command-line golfers.",
+        action = 'store_true',
+    ),
+    ParseArgument('--demand', '-D',
+        help = 'Requires at least this many units demand at the buyer (default 1)',
+        type = int,
+        default = 1,
     ),
 ]
 
@@ -61,24 +96,118 @@ def age(now: datetime, modified: datetime) -> float:
     return f"{int(delta):n}D"
 
 
-######################################################################
-# Perform query and populate result set
+def apply_game_name_shortcut(cmdenv: CommandEnv, name: str) -> str:
+    """ 
+        @internal
 
-def run(results, cmdenv, tdb):
-    # IMPORTANT: resolve stations BEFORE constructing TradeCalc
-    tdb = TradeORM(tdenv=cmdenv)
+        apply_game_lookup_term will process one of the shortcuts provided for
+        substituting a "current" system/station name from the game journal.
+
+        Currently, we're allowing '~' for "where I'm at", and '~@' for
+        "my nav target".
+
+        The nav target only exposes the system you targetted, and you might
+        not be docked, or you might want to express a different station in
+        the same system.
+
+        So we also support ~/... and ~@/...
+    """
+    game = getattr(cmdenv, "game")
+    if not game:
+        raise TradeException("Internal error: missing EliteGame journal object")
+    # Get the summary status information which has the fields we need.
+    status = game.get_status()
+
+    if name == "~":
+        require_game_data(game, location=True, status_fields=["star_system", "station_name"])
+
+        # Alias for "current station-or-system". It can only be station if they're docked.
+        if not status.docked:
+            raise CommandLineError("'~' only works while docked at a station.")
+        return f"{status.star_system}/{status.station_name}"
+
+    if name.startswith("~/"):
+        # Shortcut for "current system/..."; we just swap in the system name and
+        # let the regular parsing pick it up from there.
+        require_game_data(game, location=True, status_fields=["star_system"])
+        return f"{status.star_system}/{name[2:]}"
+
+    if name == "~@":
+        # Alias for "current nav-target system", but trade requires a station.
+        raise CommandLineError("nav route doesn't include station, please qualify ('~@/soandso')")
+
+    if name.startswith("~@/"):
+        # Shortcut for "current navtarget system/..."
+        require_game_data(game, navroute=True)
+        nav_data = game.json_data[JsonFiles.NAVROUTE]
+        cmdenv.DEBUG0("nav_data: {}", nav_data)
+        nav_route = nav_data.get("Route", None)
+        if not nav_route:
+            raise CommandLineError("'~@/...' only works when you have a nav route programmed.")
+        # The nav route is listed in jump order, so we want the last destination
+        sys_name = nav_route[-1]["StarSystem"]
+        return f"{sys_name}/{name[3:]}"
+
+    # Not something we handle; fall thru
+    return name
+
+
+def get_stations(cmdenv: CommandEnv, tdb: TradeORM) -> tuple[models.Station, models.Station]:
+    """ @internal get_stations will work out what the from/to stations are. """
+    orig_name, dest_name = cmdenv.origin, cmdenv.dest
+
+    # Do we need to consult the game?
+    if orig_name.startswith("~") or dest_name.startswith("~"):
+        orig_name = apply_game_name_shortcut(cmdenv, orig_name)
+        dest_name = apply_game_name_shortcut(cmdenv, dest_name)
     
-    lhs = tdb.lookup_station(cmdenv.origin)
+    lhs = tdb.lookup_station(orig_name)
     if not lhs:
-        raise CommandLineError(f"Unknown origin station: {cmdenv.origin}")
+        raise CommandLineError(f"Unknown origin station: {orig_name}")
     cmdenv.DEBUG0("from id: system={}, station={}", lhs.system_id, lhs.station_id)
-    rhs = tdb.lookup_station(cmdenv.dest)
+
+    rhs = tdb.lookup_station(dest_name)
     if not rhs:
-        raise CommandLineError(f"Unknown destination station: {cmdenv.dest}")
+        raise CommandLineError(f"Unknown destination station: {dest_name}")
     cmdenv.DEBUG0("to id..: system={}, station={}", rhs.system_id, rhs.station_id)
     
     if lhs == rhs:
         raise CommandLineError("Must specify two different stations.")
+
+    return lhs, rhs
+
+
+######################################################################
+# Perform query and populate result set
+
+def run(results: CommandResults, cmdenv: CommandEnv, tdb: TradeORM | None) -> CommandResults:
+    tdb = TradeORM(tdenv=cmdenv)
+
+    # Did they specify --fill?
+    full_load = getattr(cmdenv, "full_load", False)
+    want_load = getattr(cmdenv, "load", False) or full_load
+    want_fill = getattr(cmdenv, "fill", False)
+
+    # Anything that references game data means (trying) to create an object
+    if cmdenv.origin.startswith("~") or cmdenv.dest.startswith("~") or want_fill or want_load:
+        # We need to load the navroute if we're going to resolve '~@'
+        jsons = []
+        if cmdenv.origin.startswith("~@") or cmdenv.dest.startswith("~@"):
+            jsons += [JsonFiles.NAVROUTE]
+        game = EliteGame(tdenv=cmdenv, extra_jsons=jsons)
+    else:
+        game = None
+    setattr(cmdenv, "game", game)
+
+    lhs, rhs = get_stations(cmdenv, tdb)
+    if getattr(cmdenv, "reverse", False):
+        cmdenv.DEBUG0("--reverse: Reversing origin and destination")
+        lhs, rhs = rhs, lhs
+
+    # We want numbers to use in an ">" operation such that we produce
+    # `> 0` to mean "1 or more", matching the index.
+    supply_cutoff = max(getattr(cmdenv, "supply", 1), 0) - 1
+    demand_cutoff = max(getattr(cmdenv, "demand", 1), 0) - 1
     
     seller = aliased(models.StationItem, name="seller")
     buyer = aliased(models.StationItem, name="buyer")
@@ -93,10 +222,12 @@ def run(results, cmdenv, tdb):
             seller.station_id == lhs.station_id,
             buyer.station_id == rhs.station_id,
             seller.item_id == buyer.item_id,
-            seller.supply_price > 0,
-            buyer.demand_price > 0,                 # (optional extra guard)
-            buyer.demand_price >= seller.supply_price,
             seller.item_id == models.Item.item_id,
+            seller.supply_price > 0,
+            seller.supply_units > supply_cutoff,
+            buyer.demand_price > 0,                 # sqlite seems to need thi shint
+            buyer.demand_units > demand_cutoff,
+            buyer.demand_price >= seller.supply_price,
         )
         .order_by((buyer.demand_price - seller.supply_price).desc())
     )
@@ -108,8 +239,9 @@ def run(results, cmdenv, tdb):
     trades = tdb.session.execute(stmt).unique().all()
     cmdenv.DEBUG0("Raw result count: {}", len(trades))
     if not trades:
-        raise CommandLineError(f"No profitable trades {lhs.name} -> {rhs.name}")
-    
+        raise NoDataError(f"No profitable trades {lhs.name} -> {rhs.name}")
+
+
     results.summary = ResultRow(color=cmdenv.color)
     results.summary.fromStation = lhs
     results.summary.toStation = rhs
@@ -119,10 +251,45 @@ def run(results, cmdenv, tdb):
     if cmdenv.limit > 0:
         trades = trades[:cmdenv.limit]
     
+    results.summary.cargo_space = 1
+    if game and (want_fill or want_load):
+        # Ensure cargo fields aren't None.
+        need_current_cargo = not full_load  # not needed for the "to capacity" calculation
+        require_game_data(game, cargo_space=True, cargo_load=need_current_cargo)
+
+        status = game.get_status()
+
+        cargo_space = max(status.cargo_space, 0)
+        if not cargo_space:  # forgot to buy cargo modules?
+            raise TradeException("Your current ship has zero cargo capacity, Commander.")
+        
+        # If they're doing --load but not --want_load, deduct the cargo occupancy
+        if want_load and not full_load:
+            cargo_space -= max(status.cargo_load, 0)
+            if cargo_space == 0:
+                raise CommandLineError("Cargo hold is full: use --full-load if you want to ignore current cargo occupancy")
+        results.summary.cargo_space = max(cargo_space, 1)  # clamp to >= 1
+
+    units_seen = 0
     for item, sup_price, sup_units, sup_level, dem_price, dem_units, dem_level, sup_age, dem_age in trades:
+        units = min(results.summary.cargo_space, sup_units, dem_units)
+        if not units:
+            continue
         gain = dem_price - sup_price
         if gain < cmdenv.minGainPerTon:
-            continue
+            # If they've asked for a load:
+            # - if we haven't seen any units, break, indicating they can't meet that requirement,
+            # - otherwise continue filling the load so they can see there's more to be made.
+            if units_seen == 0 or not want_load:
+                break
+
+        if want_load:
+            # How much space is left?
+            spare_units = cargo_space - units_seen
+            # That constrains how much you can buy really
+            units = min(units, spare_units)
+            units_seen += units
+
         results.rows.append({
             "item": item.dbname(cmdenv.detail),
             "sup_price": sup_price,
@@ -134,14 +301,18 @@ def run(results, cmdenv, tdb):
             "sup_age": age(now, sup_age),
             "dem_age": age(now, dem_age),
             "gain": gain,
+            "units": units,
         })
-    
+        if want_load and units_seen >= cargo_space:
+            break
+
     return results
 
 #######################################################################
 ## Transform result set into output
 
 def render(results, cmdenv, tdb):
+    want_load = getattr(cmdenv, "load", False) or getattr(cmdenv, "full_load", False)
     longestNameLen = max_len(results.rows, key=lambda row: row["item"])
     
     rowFmt = RowFormat()
@@ -171,11 +342,24 @@ def render(results, cmdenv, tdb):
             key=lambda row: row["sup_age"])
         rowFmt.addColumn('DstAge', '>', 9, 's',
             key=lambda row: row["dem_age"])
-    
+
+    if results.summary.cargo_space > 1:
+        rowFmt.addColumn('|',      '>', 1,  key=lambda row: '|')
+        rowFmt.addColumn('Units',  '>', 6, key=lambda row: f'{row["units"]:n}')
+        rowFmt.addColumn('Profit', '>', 11, key=lambda row: f'{row["units"]*row["gain"]:n}')
+
+    heading, underline = rowFmt.heading()
     if not cmdenv.quiet:
         print(f"{len(results.rows)} trades found between {results.summary.fromStation.dbname()} and {results.summary.toStation.dbname()}.")
-        heading, underline = rowFmt.heading()
-        print(heading, underline, sep='\n')
-    
+        print(heading)
+        print(underline)
+
+    total_units, total_gain = 0, 0
     for row in results.rows:
+        total_units += row["units"]
+        total_gain += row["gain"] * row["units"]
         print(rowFmt.format(row))
+
+    if total_units > 0 and not cmdenv.quiet and want_load:
+        print(underline)
+        cmdenv.uprint(f"Total Units: {total_units:n}. Total Profit: {total_gain:n}.")

--- a/tradedangerous/commands/trade_cmd.py
+++ b/tradedangerous/commands/trade_cmd.py
@@ -4,7 +4,7 @@ import datetime
 import typing
 
 from .commandenv import ResultRow
-from .exceptions import CommandLineError, NoDataError
+from .exceptions import CommandLineError, NoDataError, GameDataError
 from .parsing import ParseArgument, MutuallyExclusiveGroup
 from tradedangerous import TradeException, TradeORM
 from tradedangerous.db import orm_models as models

--- a/tradedangerous/misc/timeage.py
+++ b/tradedangerous/misc/timeage.py
@@ -1,0 +1,74 @@
+""" timeage provides methods for turning numeric representations of time
+    into human-friendly 'age' strings.
+"""
+from __future__ import annotations
+import datetime
+
+
+def describe_age(age: float | int) -> str:
+    """
+        describe_age turns a duration in seconds into a text representation.
+
+        >>> describe_age(0)
+        'now'
+        >>> describe_age(-99999999.999)
+        'now'
+        >>> describe_age(1.234)
+        '<1 hr'
+        >>> describe_age(3672)
+        '1 hr'
+        >>> describe_age(9999)
+        '2 hrs'
+        >>> describe_age(86400)
+        '24 hrs'
+        >>> describe_age(86400*2 - 1)
+        '47 hrs'
+        >>> describe_age(86400*2)
+        '2 days'
+        >>> describe_age(86400*90 - 1)
+        '89 days'
+        >>> describe_age(86400*90)
+        '3 mths'
+    """
+    # Handle trivial
+    if age <= 1.0:
+        return "now"
+
+    if age < 0:
+        return "-" + describe_age(-age)
+
+    hours = int(age / 3600)
+    if hours < 1:
+        return "<1 hr"
+    if hours == 1:
+        return "1 hr"
+    if hours < 48:
+        return f"{hours} hrs"
+    days = int(hours / 24)
+    if days < 90:
+        return f"{days} days"
+    
+    return f"{int(days / 30)} mths"
+
+
+def timedelta_to_age(delta: datetime.timedelta) -> str:
+    """ timedelta_to_age returns an age representation of a datetime.timedelta. """
+    return describe_age(delta.total_seconds())
+
+
+def notz_datetime_to_age(when: datetime.datetime) -> str:
+    """
+        notz_datetime_to_age returns an age representation of a non-tz-aware datetime.datetime.
+        @see datetime_to_age if you have timezone info in your datetime.
+    """
+    now = datetime.datetime.now()
+    return timedelta_to_age(now - when)
+
+def datetime_to_age(when: datetime.datetime) -> str:
+    """
+        datetime_to_age returns an age representation of a tz-aware datetime.datetime.
+        @note requires datetimes to be timezone aware.
+        @see notz_datetime_to_age
+    """
+    now = datetime.datetime.now(tz=datetime.timezone.utc)
+    return timedelta_to_age(now - when)

--- a/tradedangerous/plugins/journal_plug.py
+++ b/tradedangerous/plugins/journal_plug.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+import datetime
+import typing
+
+from sqlalchemy import delete, func, select
+
+from tradedangerous import TradeORM
+from tradedangerous.db.orm_models import Station, Item, StationItem
+from tradedangerous.misc.timeage import datetime_to_age
+from tradedangerous.tradegame import EliteGame, JournalLoad, JsonFiles
+
+from . import PluginException, ImportPluginBase
+
+
+class ImportPlugin(ImportPluginBase):
+    """ Plugin that reads the live game journal market json and imports the values. """
+    pluginOptions = {}
+    
+    def run(self) -> bool:
+        """ Read the market journal, if it exists. """
+        tdo = TradeORM(tdenv=self.tdenv)
+
+        # Load as little as possible, all we care about is your last market update
+        game: EliteGame = EliteGame(tdenv=self.tdenv, journal_load=JournalLoad.DO_NOT_LOAD, json_files=[JsonFiles.MARKET])
+
+        market: dict[str, typing.Any] = game.json_data[JsonFiles.MARKET]
+        if not market:
+            self.tdenv.NOTE("No data in Market.json, cancelling.")
+            return False
+        timestamp = datetime.datetime.strptime(market["timestamp"], "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=datetime.timezone.utc)
+
+        market_id = market["MarketID"]
+        station_name = f"{market['StarSystem']}/{market['StationName']}"
+        station = tdo.session.get(Station, market_id)
+        if not station:
+            raise PluginException(f"Unknown station in Market.json: #{market_id}: {station_name}")
+
+        # Find when the station was last updated.
+        stmt = select(func.max(StationItem.modified)).where(StationItem.station_id == market_id)
+        last_mod = tdo.session.execute(stmt).scalar_one_or_none()
+
+        json_items = market["Items"]
+
+        self.tdenv.NOTE("[bold]{}[/] (#{}) [yellow]{}[/]: ({}) items", station_name, market_id, timestamp, len(json_items))
+        if last_mod:
+            if last_mod == timestamp:
+                self.tdenv.NOTE("Data already imported.")
+                return False
+            age = datetime_to_age(last_mod)
+            if last_mod > timestamp:
+                self.tdenv.NOTE("Database entries are more recent ([yellow]{}[/]/{}), skipping import.", last_mod, age)
+                return False
+            self.tdenv.NOTE("[green]Updating:[/green] previous entry: [yellow]{}[/]/{}", last_mod, age)
+        else:
+            self.tdenv.NOTE("[green]New Data[/green] [dim](station had no recent data)[/dim]")
+
+        # Remove any existing entries
+        stmt = delete(StationItem).where(StationItem.station_id == market_id)
+        tdo.session.execute(stmt)
+
+        # Add new ones
+        items: list[dict[str, typing.Any]] = market["Items"]
+        for item_entry in items:
+            item_id: int = item_entry["id"]
+            self.tdenv.DEBUG0("item: {}", item_entry)
+
+            # todo #1: check Item table to make sure we know about it;
+            # warn but ignore if we don't.
+            if not tdo.session.get(Item, item_id):
+                self.tdenv.WARN("Unknown item #{} [{}]", item_id, item_entry["Name_Localised"])
+                continue
+
+            demand_price: int = item_entry["SellPrice"]
+            demand_units: int = item_entry["Demand"]
+            demand_level: int = item_entry["DemandBracket"]
+            supply_price: int = item_entry["BuyPrice"]
+            supply_units: int = item_entry["Stock"]
+            supply_level: int = item_entry["StockBracket"]
+            
+            if supply_price <= 0 or supply_units <= 0 or supply_level <= 0:
+                supply_price, supply_units, supply_level = 0, 0, 0
+            
+            if not supply_price and not demand_price:
+                self.tdenv.DEBUG0("Skipping item #{} as no supply or demand", item_id)
+                continue
+
+            entry = StationItem(
+                station_id=market_id,
+                item_id=item_id,
+                demand_price=demand_price,
+                demand_units=demand_units,
+                demand_level=demand_level,
+                supply_price=supply_price,
+                supply_units=supply_units,
+                supply_level=supply_level,
+                modified=timestamp,
+                from_live=1,
+            )
+
+            tdo.session.add(entry)
+            
+        tdo.session.commit()
+        self.tdenv.NOTE("Import complete.")
+
+        return False
+
+    def finish(self) -> bool:
+        return False

--- a/tradedangerous/tradegame.py
+++ b/tradedangerous/tradegame.py
@@ -587,6 +587,8 @@ def require_game_data(
     """ Checks the game object has the data it needs to provide
         specific status fields, and if not raises an exception
         with user guidance. """
+    # Fields that we'll want to check aren't "None"
+    none_checks: set[str] = set()  # not to be confused with nun_chucks
 
     #### EVENTS
 
@@ -596,14 +598,18 @@ def require_game_data(
 
     if cargo or cargo_space:
         events.add(("Loadout",))    # The ship's load out, i.e its capacity
+        none_checks.add("cargo_space")
     if cargo or cargo_load:
         events.add(("Cargo",))      # The ship's cargo content, i.e cargo hold use
+        none_checks.add("cargo_load")
 
     if commander:
         events.add(("Commander", "LoadGame"))  # either will do
+        none_checks.add("commander")
 
     if credits:
         events.add(("Status",))
+        none_checks.add("credits")
 
     if location:
         events.add((
@@ -626,11 +632,18 @@ def require_game_data(
         if not game.json_data.get(JsonFiles.NAVROUTE, {}):
             missing.add("NavRoute data")
 
-    #### Status fields
+    #### None checks
 
-    for field in status_fields or []:
-        if getattr(game.get_status(), field, None) is None:
-            missing.add(f"'{field}' value")
+    # Now we'll check that there are meaningful values on fields the caller wants to access.
+    status: Status = game.get_status()
+
+    check_attrs = none_checks | set(status_fields or ())
+    for field in check_attrs:
+        try:
+            if getattr(status, field) is None:
+                missing.add(f"'{field}' value")
+        except AttributeError:
+            raise RuntimeError(f"Internal Error: Checking for unrecognized game-data field '{field}'")
 
     if missing:
         missing_things = sorted(missing)

--- a/tradedangerous/tradegame.py
+++ b/tradedangerous/tradegame.py
@@ -1,0 +1,640 @@
+"""
+tradegame provides the EliteGame class for accessing game journal data for Elite: Dangerous.
+
+This module provides access to current game state by reading Elite: Dangerous
+journal files and real-time status data. It extracts trade-relevant information
+such as current location, ship configuration, cargo capacity, and credits.
+
+If the journal is not in a standard place, such as on Linux or SteamDeck,
+you can set the environment variable "ELITE_JOURNAL_PATH".
+
+Journal File Format:
+    Line-delimited JSON files written to OS-specific saved games directory.
+    Each line is a complete JSON object representing a game event.
+
+Supported Data:
+    - Commander name and credits
+    - Current system and station (if docked)
+    - Ship type and configuration
+    - Cargo capacity and current cargo mass
+    - Jump range (laden and unladen)
+
+Example:
+    # Default everything.
+    from tradedangerous.tradegame import EliteGame
+    
+    game = EliteGame()
+    print(f"Commander: {game.commander_name}")
+    
+    
+Example:
+    # Builder-pattern with "TradeEnv" for arguments.
+    from tradedangerous import TradeEnv
+    from tradedangerous.tradegame import EliteGame
+    
+    tdenv = TradeEnv(debug=2, path="/Elite/Saved Games")
+    elite = EliteGame(tdenv=tdenv)
+    print(f"Current Station: {elite.current_station}")
+
+
+Example:
+    # Control which files are loaded; the same argument names can be
+    # set as properties on a tdenv instance instead.
+    from tradedangerous.tradegame import EliteGame, JournalLoad as jl, JsonFiles as jf
+    elite = EliteGame(
+                path="/Elite/Saved Games",
+                # journals alternatives: None (don't load), or an integer limit,
+                journal_load=jl.ALL_JOURNALS,
+                extra_jsons=[jf.Outfitting],
+    )
+"""
+from __future__ import annotations
+
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+import datetime
+import enum
+import os
+import re
+import time
+import typing
+
+import orjson
+
+from .tradeenv import TradeEnv
+from .tradeexcept import TradeException
+
+if typing.TYPE_CHECKING:
+    from collections.abc import Generator, Iterable
+    from typing import Any, Final
+
+
+# Environment variable to override
+ELITE_JOURNAL_ENVVAR = "ELITE_JOURNAL_PATH"
+
+
+class GameFolderError(TradeException):
+    """ GameFolderError indicates we could not find where the saved game data is. """
+    def __init__(self, msg: str) -> None:
+        super().__init__(
+            "Journal functionality needs to know where Elite's save-game data "
+            f"is stored, aka the Journal Folder: {msg}. "
+            f"Set the '{ELITE_JOURNAL_ENVVAR}' environment variable to the correct path for your machine"
+        )
+
+
+class GameException(TradeException):
+    """ GameException is base exception raised when a game file cannot be loaded or parsed."""
+
+
+class GameDataException(TradeException):
+    def __str__(self) -> str:
+        return (
+            super().__str__() + "\n" +
+            "- If you just launched the game, try again after the game has loaded.\n"
+            "- If the game is already running, you may need to change screen/dock/undock "
+                "for the game to update/generate the file\n"
+            f"- Check the journal folder is correct and/or set the {ELITE_JOURNAL_ENVVAR} environment variable\n"
+            "- This can happen if the game updates the file just as you run the command; try again"
+        )
+
+
+class JournalException(GameDataException):
+    """ JournalException is raised when a journal file cannot be loaded or parsed. """
+
+
+class JsonException(GameDataException):
+    """ JsonException is raised when a JSON file cannot be loaded or parsed. """
+
+
+class MissingJsonError(JsonException):
+    """ MissingJsonError indicates a required JSON file was not present. """
+    def __init__(self, msg: str) -> None:
+        super().__init__(f"Required save-game json data file was missing: {msg}.\n")
+
+
+@dataclass
+class Status:
+    timestamp: str | None = None
+    commander: str | None = None
+    fid: str | None = None
+    star_system: str | None = None
+    system_address: int | None = None
+    station_name: str | None = None
+    station_type: str | None = None
+    docked: bool = False
+    landed: bool = False
+    credits: int | None = None
+    destination: dict[str, Any] | None = None
+    cargo_space: int | None = None
+    cargo_load: int | None = None
+
+
+@enum.unique
+class JournalLoad(enum.IntEnum):
+    DO_NOT_LOAD  = 0
+    MOST_RECENT  = 1
+    ALL_JOURNALS = -1
+
+
+@enum.unique
+class JsonFiles(str, enum.Enum):
+    """Enumeration of supported JSON data files."""
+    BACKPACK    = "Backpack.json"
+    CARGO       = "Cargo.json"
+    MARKET      = "Market.json"
+    MODULESINFO = "ModulesInfo.json"
+    NAVROUTE    = "NavRoute.json"
+    OUTFITTING  = "Outfitting.json"
+    SHIPLOCKER  = "ShipLocker.json"
+    SHIPYARD    = "Shipyard.json"
+    STATUS      = "Status.json"
+
+
+# The format used for timestamps.
+TS_FMT = "%Y-%m-%dT%H:%M:%SZ"
+
+
+# Default journal directory paths by OS
+WINDOWS_JOURNAL_DIR: Final[Path]     = Path(Path.home(), "Saved Games", "Frontier Developments", "Elite Dangerous")
+MACOS_JOURNAL_DIR: Final[Path]       = Path(Path.home(), "Library", "Application Support", "Frontier Developments", "Elite Dangerous")
+
+
+@contextmanager
+def bench(tdenv: TradeEnv, label: str) -> Generator[None]:
+    """ Context manager bench for measuring elapsed time of code blocks. """
+    start = time.perf_counter()
+    yield
+    end = time.perf_counter()
+    elapsed = end - start
+    tdenv.DEBUG0(f"{label} took {elapsed:.6f} seconds")
+
+
+class EliteGame:
+    """
+    EliteGame class reads the various data files Frontier expose for Elite: Dangerous tools
+    to access current game state: the journal files and a collection of json files.
+    
+    By default reads the most recent journal file and DEFAULT_JSON_FILES. Additional files
+    can be loaded.
+    
+    Reads the most recent journal file to extract current game state including
+    location, ship configuration, cargo, and credits. Supports both Windows
+    and macOS journal locations.
+
+    Interpretation of the data is mostly left to the caller. Some common data can be
+    summarized for you by calling get_status().
+    
+    Example:
+        game = EliteGame()
+        status = game.get_status()
+        if status.docked:
+            print(f"Docked at {status.star_system}/{status.station_name}"
+        else:
+            print(f"In space at {status.star_system}")
+    """
+    # Class variables/Constants.
+    DEFAULT_JOURNAL_LOAD: Final[JournalLoad] = JournalLoad.MOST_RECENT
+    DEFAULT_JSON_FILES: Final[list[JsonFiles]] = [
+        JsonFiles.STATUS,       # Fairly stock data
+        JsonFiles.MODULESINFO,  # So we can determine your cargo capacity
+    ]
+    
+    # Member variables.
+    tdenv: TradeEnv                             # context object we're associated with
+    path: Path                                  # Elite's save-game folder
+    journal_load: JournalLoad                   # journal files we want to load
+    json_files: list[JsonFiles]                 # json files we want to load
+    
+    # Loaded data.
+    journals_loaded: list[Path]                 # json files we've loaded or empty
+    journal: list[dict[str, dict]]              # events in load order (oldest->newest)
+    history:  dict[str, list[dict[str, dict]]]  # oldest-first history per event name
+    events: dict[str, dict[str, Any]]           # most-recent only instance of each event
+    
+    jsons_loaded: list[JsonFiles]               # files actually loaded
+    json_data: dict[JsonFiles, dict[str, Any]]  # json file -> the data we loaded
+    
+    loaded_time: datetime.datetime              # when the load was completed
+    
+    status: Status | None                       # cache results from get_status()
+    
+    def __init__(
+        self,
+        *,
+        tdenv: TradeEnv | None = None,
+        path: str | Path | None = None,              # platform specific default
+        journal_load: JournalLoad | None = None,     # default: EliteGame.DEFAULT_JOURNAL_LOAD
+        json_files: list[JsonFiles] | None = None,   # default: EliteGame.DEFAULT_JSON_FILES
+        extra_jsons: list[JsonFiles] | None = None,  # default: []
+    ) -> None:
+        """
+            Initialize EliteGame instance by reading journal and JSON files.
+            
+            :param tdenv:        Optional TradeEnv instance for parameters, configuration, logging, etc.
+                                 If path, journal_load, and/or json_files are not provided,
+                                 tdenv will be used for defaults before falling back to the class defaults.
+            :param path:         Optional path to Elite: Dangerous saved games directory.
+                                 If not provided, uses tdenv.journal_path or discovers default based on OS.
+            :param journal_load: Optional JournalLoad enum to control if/how many journals
+                                 are loaded. If an integer value is provided, it indicates the
+                                 maximum number of journals (most recent first) to load.
+                                 If None, uses tdenv or class default.
+            :param json_files:   Optional list of JsonFiles enum values indicating
+                                   which JSON files to load. If None, uses tdenv or class default.
+        """
+        self.tdenv = tdenv or TradeEnv()
+        self.journals_loaded = []
+        self.journal = []
+        self.history = {}
+        self.events = {}
+        self.jsons_loaded = []
+        self.json_data = {}
+        self.status = None
+        
+        # Populate the options in reverse order of priority: default, tdenv, explicit parameter.
+        self.path = journal_path(self.tdenv, path)
+        self.tdenv.DEBUG0("elite journal path: {}", self.path)
+        
+        self.journal_load = self.DEFAULT_JOURNAL_LOAD
+        if tdenv and (env_journal_load := getattr(tdenv, "journal_load", None)):
+            self.journal_load = env_journal_load
+        if journal_load is not None:
+            self.journal_load = journal_load
+        self.tdenv.DEBUG1("elite game journal load: {!r}", self.journal_load)
+        
+        self.json_files = self.DEFAULT_JSON_FILES.copy()
+        if tdenv and (env_json_files := getattr(tdenv, "journal_json_files", None)) is not None:
+            self.json_files = env_json_files
+        if json_files is not None:  # explicit None check so that passing `json_files=[]` works.
+            self.json_files = json_files
+        
+        if tdenv and (env_extra_jsons := getattr(tdenv, "journal_extra_jsons", None)) is not None:
+            self.json_files.extend(env_extra_jsons)
+        if extra_jsons:
+            self.json_files.extend(extra_jsons)
+        
+        self.json_files = list(set(self.json_files))  # deduplicate
+        self.tdenv.DEBUG1("elite game json files: {!r}", self.json_files)
+
+        # self.loaded_time is set on completion of self.refresh()
+        
+        with bench(self.tdenv, "EliteGame refresh"):
+            self.refresh()
+    
+    def list_journals(self) -> list[Path]:
+        """ Returns a list of journals with the most recent first, if any are present in the journal path. """
+        journals: dict[Path, str] = {}
+        candidates: list[Path] = list(self.path.glob("Journal.*.log"))  # otherwise it's a generator
+
+        self.tdenv.DEBUG3("available: {}", candidates)
+        for journal_file in candidates:
+            # It's expected to have YYYY'-'MM'-'DD'T'HHMMSS'.'LOGN'.log',
+            # which forms a nice simple collation order number/string
+            index = re.match(r"Journal\.(\d{4})-(\d{2})-(\d{2})T(\d{6})\.(\d+)\.log$", journal_file.name)
+            if not index:
+                self.tdenv.DEBUG2("ignoring {}, doesn't match our guard pattern", journal_file)
+                continue  # ignore, no match
+            
+            self.tdenv.DEBUG3("considering {}", journal_file)
+            journals[journal_file] = "".join(index.groups())
+        
+        return sorted(journals.keys(), key=lambda file: journals[file], reverse=True)
+    
+    def refresh(self) -> None:
+        """
+        Refresh game state by re-reading journal and status files.
+        
+        Call this method to update state after game events occur. Useful
+        when polling for changes in a long-running application.
+        """
+        self.tdenv.DEBUG1("Refreshing game state")
+        self.status = None
+        with bench(self.tdenv, "_load_journals"):
+            self._load_journals()
+        with bench(self.tdenv, "_load_json_files"):
+            self._load_json_files()
+        self.loaded_time = datetime.datetime.now()
+    
+    def _load_journals(self) -> None:
+        """
+            @internal _load_journals will apply self.journal_load and
+            attempt to have the appropriate journal files loaded.
+            
+            If self.journal_load is DO_NOT_LOAD, no files are loaded and existing
+            data is cleared. If MOST_RECENT, only the most recent journal is
+            loaded. If ALL_JOURNALS, all available journals are loaded. If an
+            integer value greater than 1 is provided, upto that many are loaded -
+            most recent first.
+        """
+        # Use the journal_load to determine how many journal files we're
+        # supposed to read.
+        match self.journal_load:
+            case JournalLoad.ALL_JOURNALS:
+                max_journals = -1
+
+            case JournalLoad.DO_NOT_LOAD | int() as n if n <= 0:
+                self.journals_loaded.clear()
+                self.journal.clear()
+                self.events.clear()
+                self.tdenv.DEBUG1("JournalLoad.DO_NOT_LOAD; cleared journals")
+                return
+
+            case JournalLoad.MOST_RECENT | int() as n if n == 1:
+                max_journals = 1
+
+            case int() as n:
+                max_journals = n
+
+            case _:
+                raise GameException(f"Invalid journal load value: {self.journal_load}")
+        
+        # Sanity check: zero means zero, ie don't load anything.
+        assert max_journals != 0, "zero max_journals escaped match"
+        
+        # Fetch the full list of files
+        files = self.list_journals()
+        if not files:
+            raise JournalException(f"no journal logs found in {self.path}")
+
+        # Positive count denotes an upper cound
+        if max_journals > 0:
+            files = files[:max_journals]
+        
+        # Now we need them in the reverse order so that newer values overwrite older.
+        files.reverse()
+        
+        self.tdenv.DEBUG1("loading {} journal files: {}", len(files), files)
+        with bench(self.tdenv, "_load_journal_files"):
+            try:
+                self._load_journal_files(files)
+            except FileNotFoundError as e:
+                raise JournalException(str(e)) from None
+
+        if not self.journals_loaded:
+            raise JournalException(f"no valid journal logs found in {self.path}")
+    
+    def _add_event(self, event: dict[str, Any] | None) -> None:
+        """ @internal helper for registering an event into our fields """
+        event_name = (event or {}).get("event", None)
+        if not event_name:
+            self.tdenv.DEBUG2("ignoring non-event: {}", event)
+            return
+        
+        self.journal.append(event)
+        try:
+            self.history[event_name].append(event)
+        except KeyError:
+            self.history[event_name] = [event]
+        self.events[event_name] = event
+    
+    def _load_journal_files(self, files: list[Path], *, loader: Any = orjson.loads) -> None:
+        """
+            @internal _load_journal_files loads events from the provided list of
+            journal files into self.journals_loaded, self.journal, self.history,
+            and self.events.
+            @note silo'd for testability.
+        """
+        for journal_file in files:
+            self.tdenv.DEBUG1("loading journal file: {}", journal_file)
+            with journal_file.open("r", encoding="utf-8") as line_stream:
+                lines = iter(line_stream)
+                try:
+                    header = loader(next(lines))
+                except (StopIteration, orjson.JSONDecodeError):
+                    raise JournalException("Unable to read journals: Please wait for Elite Dangerous to finish loading") from None
+                
+                try:
+                    # Use an iterator so we can siphon off the first line as a header
+                    if not self._read_journal_header(journal_file, header):
+                        continue
+                    self.tdenv.DEBUG0(
+                        "{}: elite {} build {} lang {} odyssey {}",
+                        journal_file,
+                        header.get("gameversion", "unknown"),
+                        header.get("build", "unknown"),
+                        header.get("language", "unknown"),
+                        header.get("Odyssey", "unknown")
+                    )
+                    
+                    for line in lines:
+                        data = loader(line)
+                        self._add_event(data)
+                    
+                    self.journals_loaded.append(journal_file)
+                
+                except orjson.JSONDecodeError as e:
+                    self.tdenv.WARN("failed to parse journal file {}: {}", journal_file, e)
+    
+    def _read_journal_header(self, journal_file: Path, header: dict) -> bool:
+        """
+            @internal _read_journal_header reads and validates the header line
+            of a journal file. Returns True if successful, False to skip the file.
+            @note silo'd for testability.
+        """
+        if not isinstance(header, dict) or header.get("event", "") != "Fileheader":
+            self.tdenv.DEBUG0("ignoring invalid journal file {}, first line is not Fileheader: {}", journal_file, header)
+            return False
+        
+        event: str = header["event"]
+        if event not in self.history:
+            self.history[event] = []
+        self._add_event(header)
+        
+        return True
+    
+    def _load_json_files(self) -> None:
+        if not self.json_files:
+            self.json_data.clear()
+            self.jsons_loaded.clear()
+            self.tdenv.DEBUG1("no json files to load; cleared json data")
+            return
+        
+        for json_file_enum in set(self.json_files):
+            json_file_path = self.path / json_file_enum.value
+            self.tdenv.DEBUG1("loading json file: {}", json_file_path)
+
+            try:
+                with json_file_path.open("r", encoding="utf-8") as json_stream:
+                    data = orjson.loads(json_stream.read())
+                    self.json_data[json_file_enum] = data
+                    self.jsons_loaded += [json_file_enum]
+                    self._add_event(data)
+            except FileNotFoundError as e:
+                raise MissingJsonError(str(e)) from None
+            except orjson.JSONDecodeError as e:
+                raise JsonException(f"unable to parse save-game json file {json_file_path}: {e}") from None
+    
+    def get_status(self) -> Status:
+        """
+            get_status creates or returns a cached summary of the
+            already-loaded json status.
+        """
+        if self.status:
+            return self.status
+        
+        # Start a new one
+        status = Status()
+
+        # Collect journal events.
+        for event in self.journal:
+            match event.get("event"):
+                case "Location" | "FSJump" | "CarrierJump":
+                    status.star_system = event.get("StarSystem") or status.star_system  # incase it's empty
+                    status.system_address = event.get("SystemAddress", status.system_address)
+                    status.docked = event.get("Docked", status.docked)
+                    status.landed = event.get("Landed", status.landed)
+                    if status.docked:
+                        status.station_name = event.get("StationName", status.station_name)
+                        status.station_type = event.get("StationType", status.station_type)
+
+                case "Cargo":
+                    if event.get("Vessel") == "Ship":
+                        status.cargo_load = event.get("Count")
+                
+                case "Docked":
+                    status.docked = True
+                    status.landed = False
+                    status.station_name = event.get("StationName", status.station_name)
+                    status.station_type = event.get("StationType", status.station_type)
+                    status.star_system = event.get("StarSystem", status.star_system)
+                    status.system_address = event.get("SystemAddress", status.system_address)
+
+                case "Loadout":
+                    status.cargo_space = event.get("CargoCapacity")
+                
+                case "Undocked":
+                    status.docked = False
+                    status.station_name = None
+                    status.station_type = None
+                
+                case "Touchdown" | "Landed":
+                    status.docked = False
+                    status.landed = True
+                
+                case "Liftoff":
+                    status.docked = status.landed = False
+                
+                case "Commander":
+                    status.commander = event.get("Name")
+                    status.fid = event.get("FID")
+                
+                case "LoadGame":
+                    status.commander = event.get("Commander")
+                    status.fid = event.get("FID")
+                
+                case "Status":
+                    status.credits = event.get("Balance")
+                    status.destination = event.get("Destination")
+                
+                case _:
+                    continue  # TERMINATE
+            
+            if not status.docked and not status.landed:
+                status.station_name = status.station_type = None
+            
+            status.timestamp = event.get("timestamp", status.timestamp)
+        
+        self.status = status
+        
+        return status
+
+
+def journal_path(tdenv: TradeEnv, path: str | Path | None) -> Path:
+    """ Attempts to locate the elite savegame folder. """
+    candidate: Path | str | None = None
+    source: str | None = None
+    
+    if path:
+        # the caller is providing an explicit path, they win.
+        source, candidate = "path", path
+    elif (env_path := getattr(tdenv, "journal_path", None)):
+        # configured on the context object, it wins
+        source, candidate = "tdenv.journal_path", env_path
+    elif (env_path := os.getenv(ELITE_JOURNAL_ENVVAR, None)):
+        # environment variable fallback
+        source, candidate = ELITE_JOURNAL_ENVVAR, env_path
+    elif WINDOWS_JOURNAL_DIR.exists():
+        source, candidate = "windows", WINDOWS_JOURNAL_DIR
+    elif MACOS_JOURNAL_DIR.exists():
+        source, candidate = "macos", MACOS_JOURNAL_DIR
+    
+    if not candidate:
+        raise GameFolderError("Could not determine the default path for this machine")
+    
+    tdenv.DEBUG0("journal_path: {}: {}", source, path)
+    
+    path = Path(candidate)
+    if not path.exists():
+        raise GameFolderError(f"'{candidate}' does not exist")
+    
+    return path
+
+
+def require_game_data(
+    game: EliteGame,
+    *,
+    cargo: bool = False,        # Short for cargo_space + cargo_load
+    cargo_space: bool = False,  # Size of cargo hold
+    cargo_load: bool = False,   # Current units of cargo
+    commander: bool = False,
+    credits: bool = False,
+    location: bool = False,
+    navroute: bool = False,
+    status_fields: Iterable[str] | None = None,  # list of fields you need status to have.
+) -> None:
+    """ Checks the game object has the data it needs to provide
+        specific status fields, and if not raises an exception
+        with user guidance. """
+
+    #### EVENTS
+
+    # We require that one item from each subset is present,
+    # that is: all(any(subset) for subset in events)
+    events: set[str | Iterable[str]] = set()
+
+    if cargo or cargo_space:
+        events.add(("Loadout",))    # The ship's load out, i.e its capacity
+    if cargo or cargo_load:
+        events.add(("Cargo",))      # The ship's cargo content, i.e cargo hold use
+
+    if commander:
+        events.add(("Commander", "LoadGame"))  # either will do
+
+    if credits:
+        events.add(("Status",))
+
+    if location:
+        events.add((
+            "CarrierJump",
+            "Docked",
+            "FSJump",
+            "Location",
+        ))
+
+    missing = set()
+    for subset in events:
+        has_any = any(event in game.events for event in subset)
+        if has_any:
+            continue
+        for event in subset:
+            missing.add(event)
+
+    #### JSON loads/events
+    if navroute:
+        if not game.json_data.get(JsonFiles.NAVROUTE, {}):
+            missing.add("NavRoute data")
+
+    #### Status fields
+
+    for field in status_fields or []:
+        if getattr(game.get_status(), field, None) is None:
+            missing.add(f"'{field}' value")
+
+    if missing:
+        missing_things = sorted(missing)
+        raise GameDataException(
+            "Your current game is missing information required to "
+            f"serve this request: {', '.join(missing_things)}"
+        )

--- a/tradedangerous/tradegame.py
+++ b/tradedangerous/tradegame.py
@@ -351,7 +351,8 @@ class EliteGame:
                 raise GameException(f"Invalid journal load value: {self.journal_load}")
         
         # Sanity check: zero means zero, ie don't load anything.
-        assert max_journals != 0, "zero max_journals escaped match"
+        if max_journals == 0:
+            raise RuntimeError("Internal error: zero max_journals escaped match")
         
         # Fetch the full list of files
         files = self.list_journals()

--- a/tradedangerous/tradeorm.py
+++ b/tradedangerous/tradeorm.py
@@ -138,8 +138,11 @@ class TradeORM:
             results = stmt.all()
             if len(results) == 1:
                 return results[0]
+
             stmt = self.session.query(orm.Station).filter(orm.Station.system_id == system.system_id).filter(orm.Station.name.like(f"%{stn_name}%"))
             results = stmt.all()
+            if not results:
+                raise TradeException(f"no station in {sys_name} matches '{stn_name}'")
             if len(results) > 1:
                 raise AmbiguityError("Station", stn_name, [s.name for s in results])
             return results[0]


### PR DESCRIPTION
The experiment was: What if TD had some minimal support for the network journal?

This isn't intended to be an all-bells-and-whistles component; it reads the journals somewhat naively, doesn't provide a billion methods for accessing this and that.

I stop at some trade-useful data: what's your ship and where is it at; if your thing needs more, the data is here in dict format.

For now it consists of some hacks in the "trade" sub command:
`~` for current system/station, and `~@` for nav-target system,

```
trade.py trade ~ "~@/stronghold carrier"
```

If you have a nav target, this would try and find trades between your currently-docked station and the stronghold carrier your nav target system.

```
trade.py import -P journal
```
will read in the prices from your last visited commodities market.

