### PR TITLE
feat: make ctrl-c during trade run show the route as-calculated

### DIFF
--- a/trade.py
+++ b/trade.py
@@ -35,7 +35,7 @@
 # to empower other programmers to do cool stuff.
 import sys
 
-from tradedangerous import cli
+from tradedangerous import cli, SimpleAbort
 
 
 def main(argv = None):
@@ -43,4 +43,7 @@ def main(argv = None):
 
 
 if __name__ == "__main__":
-    cli.main(sys.argv)
+    try:
+        cli.main(sys.argv)
+    except SimpleAbort as e:
+        print(str(e))

--- a/tradedangerous/__init__.py
+++ b/tradedangerous/__init__.py
@@ -21,12 +21,11 @@ from a website such as [Tromador's Trading Dangerously](http://elite.ripz.org "T
 from .tradecalc import TradeCalc
 from .tradedb import TradeDB
 from .tradeenv import TradeEnv
-from .tradeexcept import TradeException
+from .tradeexcept import SimpleAbort, TradeException
 from .tradeorm import TradeORM
 from .version import __version__
 
 from .commands.commandenv import CommandEnv, CommandResults
-
 
 # Export this as top-level symbnols so they can be imported with e.g.
 #  import tradedangerous.TradeDB
@@ -35,6 +34,7 @@ __all__ = [
     '__version__',
     'CommandEnv',
     'CommandResults',
+    'SimpleAbort',
     'TradeCalc',
     'TradeDB',
     'TradeEnv',

--- a/tradedangerous/cli.py
+++ b/tradedangerous/cli.py
@@ -124,6 +124,9 @@ def trade(argv):
 
     try:
         results = cmdenv.run(tdb)
+    except tradeexcept.SimpleAbort as e:
+        cmdenv.console.print(f"\n{e}\n", style="red")
+        sys.exit(1)
     finally:
         # always close tdb
         tdb.close(final=True)

--- a/tradedangerous/commands/run_cmd.py
+++ b/tradedangerous/commands/run_cmd.py
@@ -723,6 +723,7 @@ def checkOrigins(tdb, cmdenv, calc):
     # Compute eligibility once: stations must both sell and buy (same as suitability with src=None).
     eligible_ids = set(calc.stationsSelling) & set(calc.stationsBuying)
     
+    setattr(cmdenv, "_origin", cmdenv.origPlace)  # store the original so we can overwrite it
     if cmdenv.origPlace:
         if cmdenv.startJumps and cmdenv.startJumps > 0:
             cmdenv.origins = expandForJumps(
@@ -1347,8 +1348,11 @@ def run(results, cmdenv, tdb):
 
         except KeyboardInterrupt:
             cmdenv.DEBUG0("** Keyboard Interrupt")
-            if hopNo == 0 or not pickedRoutes:
+            if hopNo == 0 or not routes:
                 raise UserAbortedRun("before any routes calculated")
+            # Until python 3.14 it's discouraged to break from an exception, so
+            # lets make sure we don't mistake there being anything to process.
+            calc.aborted = True
             newRoutes = []
 
         except NoHopsError:
@@ -1367,8 +1371,6 @@ def run(results, cmdenv, tdb):
 
         if calc.aborted:
             cmdenv.DEBUG0("** User Aborted")
-            if not newRoutes:
-                raise UserAbortedRun("unable to surface any routes [internal error]")
             break
 
         if not newRoutes:
@@ -1428,7 +1430,6 @@ def run(results, cmdenv, tdb):
     
     if not routes:
         if calc.aborted:
-            cmdenv.WARN("Internal Error: abort continued without routes, please report on github")
             raise UserAbortedRun("before any routes found")
         raise NoDataError(
             "No profitable trades matched your critera, or price data along the route is missing."
@@ -1454,27 +1455,35 @@ def no_routes_on_first_hop(cmdenv: TradeEnv, calc: TradeCalc) -> None:
     if calc.aborted:
         raise UserAbortedRun("during first hop before any routes found")
 
-    if cmdenv.origPlace:
-        start_place = cmdenv.starting or "???"
-        start_system = cmdenv.origPlace.system.name()
-        max_ly = cmdenv.maxJumpsPer * cmdenv.maxLyPer
+    # The raw name they provide with --from is stored as cmdenv.starting, and resolved
+    # to a System or Station in cmdenv.origPlace, however checkOrigins may set that to
+    # None if we're doing --start-jumps to indicate there's no "single" origin. So we
+    # saved a copy of it to cmdenv._origin.
+    start_place = getattr(cmdenv, "_origin")
+    if not start_place:
+        # Ok, we were doing some kind of open-ended galaxy wide query
+        raise NoDataError("Could not find any trade links in the galaxy with those criteria.")
+
+    # Find the system name - all "locations" have a system property including Systems.
+    start_system = start_place.system.name()
+
+    # How far did you say you were willing to go?
+    max_ly = cmdenv.maxJumpsPer * cmdenv.maxLyPer
         
-        errText = (
-            f"No profitable buyers found for the goods at {start_place}.\n"
+    errText = (
+        f"No suitable and profitable buyers found at/relative to {start_place}.\n"
+        "\n"
+        "You may want to try:\n"
+        f"  {sys.argv[0]} local \"{start_system}\" --ly {max_ly} -vv --stations --trading"
+    )
+        
+    # If they had specified a station, give them a little extra help.
+    if isinstance(start_place, Station):
+        errText += (
             "\n"
-            "You may want to try:\n"
-            f"  {sys.argv[0]} local \"{start_system}\" --ly {max_ly} -vv --stations --trading"
+            "or:\n"
+            f"  {sys.argv[0]} market \"{start_place}\" --sell -vv"
         )
-        
-        # If they had specified a station, give them a little extra help.
-        if isinstance(cmdenv.origPlace, Station):
-            errText += (
-                "\n"
-                "or:\n"
-                f"  {sys.argv[0]} market \"{start_place}\" --sell -vv"
-            )
-    else:
-        errText = "Could not find any trade links in the galaxy with those criteria."
     
     raise NoDataError(errText)
 

--- a/tradedangerous/commands/run_cmd.py
+++ b/tradedangerous/commands/run_cmd.py
@@ -1,3 +1,13 @@
+from __future__ import annotations
+from itertools import chain
+import math
+import sys
+import time
+import typing
+
+from tradedangerous.tradedb import describeAge, Station, System
+from tradedangerous.tradecalc import NoHopsError, Route, TradeCalc, UserAbortedRun
+
 from .commandenv import ResultRow
 from .exceptions import CommandLineError, NoDataError
 from .parsing import (
@@ -5,13 +15,9 @@ from .parsing import (
     NoPlanetSwitch, OdysseyArgument, PadSizeArgument, ParseArgument,
     PlanetaryArgument,
 )
-from itertools import chain
-from ..tradedb import TradeDB, System, Station, describeAge
-from ..tradecalc import TradeCalc, Route, NoHopsError
 
-import math
-import sys
-import time
+if typing.TYPE_CHECKING:
+    from tradedangerous import TradeDB, TradeEnv
 
 
 ######################################################################
@@ -261,6 +267,7 @@ switches = [
         action = 'store_true',
     ),
 ]
+
 
 ######################################################################
 # Helpers
@@ -1303,7 +1310,7 @@ def run(results, cmdenv, tdb):
         if distancePruning:
             preCrop = len(routes)
             distLeft = maxHopDistLy * (numHops - hopNo)
-            routes = [rt for rt in routes if distancePruning(rt, distLeft)]
+            routes[:] = [rt for rt in routes if distancePruning(rt, distLeft)]
             if not routes:
                 if pickedRoutes:
                     break
@@ -1311,8 +1318,7 @@ def run(results, cmdenv, tdb):
                     "No routes are in-range of any end stations at the end of hop {}"
                     .format(hopNo)
                 )
-            pruned = preCrop - len(routes)
-            if pruned:
+            if (pruned := preCrop - len(routes)):
                 cmdenv.NOTE("Pruned {} origins too far from any end stations", pruned)
         
         if hopNo >= 1 and (cmdenv.maxRoutes or pruneMod):
@@ -1338,6 +1344,13 @@ def run(results, cmdenv, tdb):
         
         try:
             newRoutes = calc.getBestHops(routes, restrictTo = restrictTo)
+
+        except KeyboardInterrupt:
+            cmdenv.DEBUG0("** Keyboard Interrupt")
+            if hopNo == 0 or not pickedRoutes:
+                raise UserAbortedRun("before any routes calculated")
+            newRoutes = []
+
         except NoHopsError:
             if hopNo == 0 and len(cmdenv.origSystems) == 1:
                 raise NoDataError(
@@ -1351,50 +1364,38 @@ def run(results, cmdenv, tdb):
             raise NoDataError(
                 "No routes had reachable trading links at hop #{}".format(hopNo + 1)
             )
-        
+
+        if calc.aborted:
+            cmdenv.DEBUG0("** User Aborted")
+            if not newRoutes:
+                raise UserAbortedRun("unable to surface any routes [internal error]")
+            break
+
         if not newRoutes:
+            assert not calc.aborted, "internal error"
+            # First attempt to find a route is a special case because the current
+            # route list is the source.
+            if hopNo == 0:
+                no_routes_on_first_hop(cmdenv, calc)
+                # no return
+
+            # If we've already got some winners (e.g. on --shorten)
             if pickedRoutes:
                 break
+
             checkReachability(tdb, cmdenv)
-            if hopNo > 0:
-                if restrictTo and manualRestriction:
-                    results.summary.exception += routeFailedRestrictions(
-                        tdb, cmdenv, restrictTo, maxLs, hopNo
-                    )
-                    break
-                results.summary.exception += (
-                    "SORRY: Could not find profitable destinations "
-                    "beyond hop #{:n}\n"
-                    .format(hopNo + 1)
+
+            if restrictTo and manualRestriction:
+                results.summary.exception += routeFailedRestrictions(
+                    tdb, cmdenv, restrictTo, maxLs, hopNo
                 )
                 break
 
-            if cmdenv.origPlace and len(routes) == 1:
-                errText = (
-                    "No profitable buyers found for the goods at {}.\n"
-                    "\n"
-                    "You may want to try:\n"
-                    "  {} local \"{}\" --ly {} -vv --stations --trading"
-                    .format(
-                        routes[0].lastStation.name(),
-                        sys.argv[0], cmdenv.origPlace.system.name(),
-                        cmdenv.maxJumpsPer * cmdenv.maxLyPer,
-                    )
-                )
-                if isinstance(cmdenv.origPlace, Station):
-                    errText += (
-                        "\n"
-                        "or:\n"
-                        "  {} market \"{}\" --sell -vv"
-                        .format(
-                            sys.argv[0], cmdenv.origPlace.name(),
-                        )
-                    )
-                raise NoDataError(errText)
-            raise NoDataError("Unable to find any profitable buyers for first hop.")
-    
+            results.summary.exception += f"SORRY: Could not find profitable destinations beyond hop #{hopNo+1:n}\n"
+            break
+        
         routes[:] = newRoutes
-        if routes and goalSystem:
+        if goalSystem:
             # Promote the winning route to the top of the list
             # while leaving the remainder of the list intact
             routes.sort(
@@ -1405,6 +1406,9 @@ def run(results, cmdenv, tdb):
                 cmdenv.NOTE("Goal system reached!")
                 routes = routes[:1]
                 break
+        
+        if calc.aborted:
+            break
         
         if routePickPred:
             pickedRoutes.extend(
@@ -1423,9 +1427,11 @@ def run(results, cmdenv, tdb):
             route.score /= len(route.hops)
     
     if not routes:
+        if calc.aborted:
+            cmdenv.WARN("Internal Error: abort continued without routes, please report on github")
+            raise UserAbortedRun("before any routes found")
         raise NoDataError(
-            "No profitable trades matched your critera, "
-            "or price data along the route is missing."
+            "No profitable trades matched your critera, or price data along the route is missing."
         )
     
     if viaSet:
@@ -1435,20 +1441,64 @@ def run(results, cmdenv, tdb):
     
     routes.sort()
     results.data = routes
+
+    if calc.aborted:
+        results.summary.exception += str(UserAbortedRun("results may be incomplete or inaccurate")) + "\n"
     
     return results
+
+
+def no_routes_on_first_hop(cmdenv: TradeEnv, calc: TradeCalc) -> None:
+    """ handle the special case where run found no routes on the first hop. """
+    # Is it because you ctrl-c'd?
+    if calc.aborted:
+        raise UserAbortedRun("during first hop before any routes found")
+
+    if cmdenv.origPlace:
+        start_place = cmdenv.starting or "???"
+        start_system = cmdenv.origPlace.system.name()
+        max_ly = cmdenv.maxJumpsPer * cmdenv.maxLyPer
+        
+        errText = (
+            f"No profitable buyers found for the goods at {start_place}.\n"
+            "\n"
+            "You may want to try:\n"
+            f"  {sys.argv[0]} local \"{start_system}\" --ly {max_ly} -vv --stations --trading"
+        )
+        
+        # If they had specified a station, give them a little extra help.
+        if isinstance(cmdenv.origPlace, Station):
+            errText += (
+                "\n"
+                "or:\n"
+                f"  {sys.argv[0]} market \"{start_place}\" --sell -vv"
+            )
+    else:
+        errText = "Could not find any trade links in the galaxy with those criteria."
+    
+    raise NoDataError(errText)
+
 
 ######################################################################
 # Transform result set into output
 
 
 def render(results, cmdenv, tdb):
-    exception = results.summary.exception
-    if exception:
-        print('#' * 76)
-        print("\a{}".format(exception), end = "")
-        print('#' * 76)
-        print()
+    if (exception := results.summary.exception.strip()):
+        style = ""
+        lines = exception.split("\n")
+        max_line_len = max(len(line) for line in lines)
+        if cmdenv.color:
+            style = "yellow on grey15"  # yellow on a darkish background, so we're sure it's not on a light background
+            # Pad all the lines to the same length
+            exception = "\n".join(f"{line:{max_line_len}s}" for line in lines)
+
+        # TODO: should use a rich panel when --color is set
+        cmdenv.console.print('#' * max_line_len, style=style)
+        cmdenv.console.print(exception, style=style)
+        cmdenv.console.print('#' * max_line_len, style=style)
+        # Ring the console bell and add a blank line
+        cmdenv.console.print("\a")
     
     routes = results.data
     

--- a/tradedangerous/tradecalc.py
+++ b/tradedangerous/tradecalc.py
@@ -57,7 +57,7 @@ import typing
 from sqlalchemy import text as _sa_text
 
 from .tradedb import Item
-from .tradeexcept import TradeException
+from .tradeexcept import SimpleAbort, TradeException
 # Legacy-style helpers (these remain expected by other modules)
 from .tradedb import Trade, Destination, describeAge
 
@@ -73,6 +73,19 @@ locale.setlocale(locale.LC_ALL, '')
 
 ######################################################################
 # Exceptions
+
+
+class UserAbortedRun(SimpleAbort):
+    """
+    UserAbortedRunError is raised when a user hits ctrl-c during a
+    route calculation after useful work has been done that we may
+    still want to report to the user.
+
+    If there is no useful work, then we should probably allow the
+    ctrl-c to just fall thru.
+    """
+    def __str__(self) -> str:
+        return f"*** Ctrl+C: User aborted run: {super().__str__()}"
 
 
 class BadTimestampError(TradeException):
@@ -516,6 +529,38 @@ class Route:
         )
 
 
+def sigmoid(x: float | int) -> float:
+    # [eyeonus]:
+    # (Keep in mind all this ignores values of x<0.)
+    # The sigmoid: (1-(25(x-1))/(1+abs(25(x-1))))/4
+    # ranges between 0.5 and 0 with a drop around x=1,
+    # which makes it great for giving a boost to distances < 1Kls.
+    #
+    # The sigmoid: (-1-(50(x-4))/(1+abs(50(x-4))))/4
+    # ranges between 0 and -0.5 with a drop around x=4,
+    # making it great for penalizing distances > 4Kls.
+    #
+    # The curve: (-1+1/(x+1)^((x+1)/4))/2
+    # ranges between 0 and -0.5 in a smooth arc,
+    # which will be used for making distances
+    # closer to 4Kls get a slightly higher penalty
+    # then distances closer to 1Kls.
+    #
+    # Adding the three together creates a doubly-kinked curve
+    # that ranges from ~0.5 to -1.0, with drops around x=1 and x=4,
+    # which closely matches ksfone's intention without going into
+    # negative numbers and causing problems when we add it to
+    # the multiplier variable. ( 1 + -1 = 0 )
+    #
+    # You can see a graph of the formula here:
+    # https://goo.gl/sn1PqQ
+    # NOTE: The black curve is at a penalty of 0%,
+    # the red curve at a penalty of 100%, with intermediates at
+    # 25%, 50%, and 75%.
+    # The other colored lines show the penalty curves individually
+    # and the teal composite of all three.
+    return x / (1 + abs(x))
+
 class TradeCalc:
     """
     Container for accessing trade calculations with common properties.
@@ -537,6 +582,7 @@ class TradeCalc:
             tdenv = tdb.tdenv
         self.tdb = tdb
         self.tdenv = tdenv
+        self.aborted: bool = False
         self.defaultFit = fit or self.simpleFit
         if "BRUTE_FIT" in os.environ:
             self.defaultFit = self.bruteForceFit
@@ -945,6 +991,7 @@ class TradeCalc:
         Keeps only the best candidate per destination station for this hop.
         """
     
+        self.aborted = False
         tdb = self.tdb
         tdenv = self.tdenv
         avoidPlaces = getattr(tdenv, "avoidPlaces", None) or ()
@@ -1080,190 +1127,167 @@ class TradeCalc:
         getSelling = self.stationsSelling.get
     
         for route_no, route in enumerate(routes):
-            if tdenv.debug > 1:  # route.debug_text can be expensive, so avoid evaluating it
-                tdenv.DEBUG1("Route = {}", route.debug_text(lambda x, y: y))
-    
-            srcStation = route.lastStation
-            startCr = credits + int(route.gainCr * safetyMargin)
-    
-            srcSelling = getSelling(srcStation.ID, None)
-            if not srcSelling:
-                tdenv.DEBUG1("Nothing sold at source - next.")
-                if heartbeat_enabled:
-                    heartbeat(route_no + 1, 0)
-                continue
-    
-            srcSelling = tuple(values for values in srcSelling if values[1] <= startCr)
-            if not srcSelling:
-                tdenv.DEBUG1("Nothing affordable - next.")
-                if heartbeat_enabled:
-                    heartbeat(route_no + 1, 0)
-                continue
-    
-            if goalSystem:
-                origSystem = route.firstSystem
-                srcSystem = srcStation.system
-                srcDistTo = srcSystem.distanceTo
-                goalDistTo = goalSystem.distanceTo
-                origDistTo = origSystem.distanceTo
-                srcGoalDist = srcDistTo(goalSystem)
-                srcOrigDist = srcDistTo(origSystem)
-                origGoalDist = origDistTo(goalSystem)
-    
-            if unique:
-                uniquePath = route.route
-            elif loopInt:
-                pos_from_end = 0 - loopInt
-                uniquePath = route.route[pos_from_end:-1]
-    
-            stations = (
-                d
-                for d in station_iterator(srcStation, route_no + 1)
-                if (d.station != srcStation)
-                and (d.station.blackMarket == "Y" if reqBlackMarket else True)
-                and (d.station not in uniquePath if uniquePath else True)
-                and (d.station in restrictStations if restrictStations else True)
-                and (d.station.dataAge and d.station.dataAge <= maxAge if maxAge else True)
-                and (
-                    (
-                        (d.system is not srcSystem)
-                        if bool(tdenv.unique)
-                        else (d.system is goalSystem or d.distLy < srcGoalDist)
-                    )
-                    if goalSystem
-                    else True
-                )
-            )
-    
-            # Even when we don't log the line, we still have to produce the
-            # parameters, and building the route list could be expensive,
-            # so only pay the cost when we're actually logging.
-            if tdenv.debug > 1:
-                def annotate(dest):
-                    tdenv.DEBUG1(
-                        "destSys {}, destStn {}, jumps {}, distLy {}",
-                        dest.system.dbname,
-                        dest.station.dbname,
-                        "->".join(jump.text() for jump in dest.via),
-                        dest.distLy,
-                    )
-                    return dest
-                stations = (annotate(d) for d in stations)
-    
-            for dest in stations:
-                dstStation = dest.station
-                connections += 1
-    
-                items = self.getTrades(srcStation, dstStation, srcSelling)
-                if not items:
+            try:
+                if tdenv.debug > 1:  # route.debug_text can be expensive, so avoid evaluating it
+                    tdenv.DEBUG1("Route = {}", route.debug_text(lambda x, y: y))
+        
+                srcStation = route.lastStation
+                startCr = credits + int(route.gainCr * safetyMargin)
+        
+                srcSelling = getSelling(srcStation.ID, None)
+                if not srcSelling:
+                    tdenv.DEBUG1("Nothing sold at source - next.")
+                    if heartbeat_enabled:
+                        heartbeat(route_no + 1, 0)
                     continue
-                trade = fitFunction(items, startCr, capacity, maxUnits)
-    
-                multiplier = 1.0
-                # Calculate total K-lightseconds supercruise time.
-                # This will amortize for the start/end stations
-                dstSys = dest.system
-                if goalSystem and dstSys is not goalSystem:
-                    # Biggest reward for shortening distance to goal
-                    dstGoalDist = goalDistTo(dstSys)
-                    # bias towards bigger reductions
-                    score = 5000 * origGoalDist / dstGoalDist
-                    # discourage moving back towards origin
-                    score += 50 * srcGoalDist / dstGoalDist
-                    # Gain per unit pays a small part
-                    if dstSys is not origSystem:
-                        score += 10 * (origDistTo(dstSys) - srcOrigDist)
-                    score += (trade.gainCr / trade.units) / 25
-                else:
-                    score = trade.gainCr
-    
-                if lsPenalty:
-                    def sigmoid(x):
-                        # [eyeonus]:
-                        # (Keep in mind all this ignores values of x<0.)
-                        # The sigmoid: (1-(25(x-1))/(1+abs(25(x-1))))/4
-                        # ranges between 0.5 and 0 with a drop around x=1,
-                        # which makes it great for giving a boost to distances < 1Kls.
-                        #
-                        # The sigmoid: (-1-(50(x-4))/(1+abs(50(x-4))))/4
-                        # ranges between 0 and -0.5 with a drop around x=4,
-                        # making it great for penalizing distances > 4Kls.
-                        #
-                        # The curve: (-1+1/(x+1)^((x+1)/4))/2
-                        # ranges between 0 and -0.5 in a smooth arc,
-                        # which will be used for making distances
-                        # closer to 4Kls get a slightly higher penalty
-                        # then distances closer to 1Kls.
-                        #
-                        # Adding the three together creates a doubly-kinked curve
-                        # that ranges from ~0.5 to -1.0, with drops around x=1 and x=4,
-                        # which closely matches ksfone's intention without going into
-                        # negative numbers and causing problems when we add it to
-                        # the multiplier variable. ( 1 + -1 = 0 )
-                        #
-                        # You can see a graph of the formula here:
-                        # https://goo.gl/sn1PqQ
-                        # NOTE: The black curve is at a penalty of 0%,
-                        # the red curve at a penalty of 100%, with intermediates at
-                        # 25%, 50%, and 75%.
-                        # The other colored lines show the penalty curves individually
-                        # and the teal composite of all three.
-                        return x / (1 + abs(x))
-                    # [kfsone] Only want 1dp
-                    # Produce a curve that favors distances under 1kls
-                    # positively, starts to penalize distances over 1k,
-                    # and after 4kls starts to penalize aggressively
-                    # http://goo.gl/Otj2XP
-                        
-                    # [eyeonus] As aadler pointed out, this goes into negative
-                    # numbers, which causes problems.
-                    # penalty = ((cruiseKls ** 2) - cruiseKls) / 3
-                    # penalty *= lsPenalty
-                    # multiplier *= (1 - penalty)
-                    cruiseKls = int(dstStation.lsFromStar / 100) / 10
-                    boost = (1 - sigmoid(25 * (cruiseKls - 1))) / 4
-                    drop = (-1 - sigmoid(50 * (cruiseKls - 4))) / 4
-                    try:
-                        penalty = (-1 + 1 / (cruiseKls + 1) ** ((cruiseKls + 1) / 4)) / 2
-                    except OverflowError:
-                        penalty = -0.5
-                    multiplier += (penalty + boost + drop) * lsPenalty
-    
-                score *= multiplier
-    
-                # update hop-global best score (nearest int)
-                try:
-                    si = int(round(score))
-                except TypeError:
-                    si = int(score)
-                if si > best_seen_score:
-                    best_seen_score = si
-    
-                dstID = dstStation.ID
-                try:
-                    btd = bestToDest[dstID]
-                except KeyError:
-                    pass
-                else:
-                    bestRoute = btd[1]
-                    bestScore = btd[5]
-                    bestTradeScore = bestRoute.score + bestScore
-                    newTradeScore = route.score + score
-                    if bestTradeScore > newTradeScore:
-                        continue
-                    if bestTradeScore == newTradeScore:
-                        bestLy = btd[4]
-                        if bestLy <= dest.distLy:
-                            continue
-    
-                bestToDest[dstID] = (
-                    dstStation,
-                    route,
-                    trade,
-                    dest.via,
-                    dest.distLy,
-                    score,
+        
+                srcSelling = tuple(values for values in srcSelling if values[1] <= startCr)
+                if not srcSelling:
+                    tdenv.DEBUG1("Nothing affordable - next.")
+                    if heartbeat_enabled:
+                        heartbeat(route_no + 1, 0)
+                    continue
+        
+                if goalSystem:
+                    origSystem = route.firstSystem
+                    srcSystem = srcStation.system
+                    srcDistTo = srcSystem.distanceTo
+                    goalDistTo = goalSystem.distanceTo
+                    origDistTo = origSystem.distanceTo
+                    srcGoalDist = srcDistTo(goalSystem)
+                    srcOrigDist = srcDistTo(origSystem)
+                    origGoalDist = origDistTo(goalSystem)
+        
+                if unique:
+                    uniquePath = route.route
+                elif loopInt:
+                    pos_from_end = 0 - loopInt
+                    uniquePath = route.route[pos_from_end:-1]
+        
+                stations = (
+                    d
+                    for d in station_iterator(srcStation, route_no + 1)
+                    if (d.station != srcStation)
+                    and (d.station.blackMarket == "Y" if reqBlackMarket else True)
+                    and (d.station not in uniquePath if uniquePath else True)
+                    and (d.station in restrictStations if restrictStations else True)
+                    and (d.station.dataAge and d.station.dataAge <= maxAge if maxAge else True)
+                    and (
+                        (
+                            (d.system is not srcSystem)
+                            if bool(tdenv.unique)
+                            else (d.system is goalSystem or d.distLy < srcGoalDist)
+                        )
+                        if goalSystem
+                        else True
+                    )
                 )
+        
+                # Even when we don't log the line, we still have to produce the
+                # parameters, and building the route list could be expensive,
+                # so only pay the cost when we're actually logging.
+                if tdenv.debug > 1:
+                    def annotate(dest):
+                        tdenv.DEBUG1(
+                            "destSys {}, destStn {}, jumps {}, distLy {}",
+                            dest.system.dbname,
+                            dest.station.dbname,
+                            "->".join(jump.text() for jump in dest.via),
+                            dest.distLy,
+                        )
+                        return dest
+
+                    stations = (annotate(d) for d in stations)
+        
+                for dest in stations:
+                    dstStation = dest.station
+                    connections += 1
+        
+                    items = self.getTrades(srcStation, dstStation, srcSelling)
+                    if not items:
+                        continue
+                    trade = fitFunction(items, startCr, capacity, maxUnits)
+        
+                    multiplier = 1.0
+                    # Calculate total K-lightseconds supercruise time.
+                    # This will amortize for the start/end stations
+                    dstSys = dest.system
+                    if goalSystem and dstSys is not goalSystem:
+                        # Biggest reward for shortening distance to goal
+                        dstGoalDist = goalDistTo(dstSys)
+                        # bias towards bigger reductions
+                        score = 5000 * origGoalDist / dstGoalDist
+                        # discourage moving back towards origin
+                        score += 50 * srcGoalDist / dstGoalDist
+                        # Gain per unit pays a small part
+                        if dstSys is not origSystem:
+                            score += 10 * (origDistTo(dstSys) - srcOrigDist)
+                        score += (trade.gainCr / trade.units) / 25
+                    else:
+                        score = trade.gainCr
+        
+                    if lsPenalty:
+                        # [kfsone] Only want 1dp
+                        # Produce a curve that favors distances under 1kls
+                        # positively, starts to penalize distances over 1k,
+                        # and after 4kls starts to penalize aggressively
+                        # http://goo.gl/Otj2XP
+                            
+                        # [eyeonus] As aadler pointed out, this goes into negative
+                        # numbers, which causes problems.
+                        # penalty = ((cruiseKls ** 2) - cruiseKls) / 3
+                        # penalty *= lsPenalty
+                        # multiplier *= (1 - penalty)
+                        cruiseKls = int(dstStation.lsFromStar / 100) / 10
+                        boost = (1 - sigmoid(25 * (cruiseKls - 1))) / 4
+                        drop = (-1 - sigmoid(50 * (cruiseKls - 4))) / 4
+                        try:
+                            penalty = (-1 + 1 / (cruiseKls + 1) ** ((cruiseKls + 1) / 4)) / 2
+                        except OverflowError:
+                            penalty = -0.5
+                        multiplier += (penalty + boost + drop) * lsPenalty
+        
+                    score *= multiplier
+        
+                    # update hop-global best score (nearest int)
+                    try:
+                        si = int(round(score))
+                    except TypeError:
+                        si = int(score)
+                    if si > best_seen_score:
+                        best_seen_score = si
+        
+                    dstID = dstStation.ID
+                    try:
+                        btd = bestToDest[dstID]
+                    except KeyError:
+                        pass
+                    else:
+                        bestRoute = btd[1]
+                        bestScore = btd[5]
+                        bestTradeScore = bestRoute.score + bestScore
+                        newTradeScore = route.score + score
+                        if bestTradeScore > newTradeScore:
+                            continue
+                        if bestTradeScore == newTradeScore:
+                            bestLy = btd[4]
+                            if bestLy <= dest.distLy:
+                                continue
+        
+                    bestToDest[dstID] = (
+                        dstStation,
+                        route,
+                        trade,
+                        dest.via,
+                        dest.distLy,
+                        score,
+                    )
+            except KeyboardInterrupt:
+                self.aborted = True
+                if not bestToDest:
+                    # Let the caller decide how to handle, explicitly
+                    raise
+                break
     
         if heartbeat_enabled:
             sys.stderr.write("\n")

--- a/tradedangerous/tradeexcept.py
+++ b/tradedangerous/tradeexcept.py
@@ -16,6 +16,13 @@ if typing.TYPE_CHECKING:
 AMBIGUITY_LIMIT = 6
 
 
+class SimpleAbort(Exception):
+    """
+        SimpleAbort is Exception but can be caught and presented without
+        any kind of backtrace.
+    """
+
+
 class TradeException(Exception):
     """
         Distinguishes runtime logical errors (such as no data for what you


### PR DESCRIPTION
This feature allows you to interrupt a long running multi-hop route calculation without losing all that processing work...

```
Win|pwsh> python trade.py run --from shinrar/memorial --ly 150 --jumps 1 --hops 4 --cr 370m --cap 1088 --gpt 8000 --age 3 --pad l --fc=n --detail --detail --progress --prune-score=40 Searching for quality trades. This may take a few minutes. Please be patient. \ Scanning market data… rows 1,392,753  kept: buys 1,384,326, sells 418,838 | Scanning stations…  examined 1  kept 1
* Hop   1: .........1 origins
| origin 1/1  destinations checked: 1  best score: 0
* Hop   2: ........45 origins .. 9,095,680-27,890,880cr gain, 8,360-25,635cr/ton
/ origin 43/45  destinations checked: 3,537  best score: 27,688,173
NOTE: Pruned 299 origins
* Hop   3: .......450 origins .. 23,700,992-40,815,232cr gain, 10,892-18,757cr/ton
\ origin 31/450  destinations checked: 2,353  best score: 32,072,684
*** Ctrl-C Interrupt, stopping search...

############################################################################
User aborted route calculation.
############################################################################

Shinrarta Dezhra/Jameson Memorial -> Tionisla/Ing Ring (score: 68326125.735657)
  Load from Shinrarta Dezhra/Jameson Memorial (345ls, Pad:L, Plt:N, Flc:N, Ody:N, Shp:Y, Out:Y):
     1088 x Legal Drugs/Agronomic Treatment    2,860cr vs   15,427cr, <1 hr vs <1 hr
  Unload at Barnard's Star/Pohl Metallurgic Station (61ls, Pad:L, Plt:Y, Flc:N, Ody:Y, Shp:N, Out:N) => Gain 13,672,896cr (12,567cr/ton) => 383,672,896cr
  Load from Barnard's Star/Pohl Metallurgic Station (61ls, Pad:L, Plt:Y, Flc:N, Ody:Y, Shp:N, Out:N):
      639 x Consumer Items/Cryolite           10,510cr vs   29,428cr, <1 hr vs 1 hr
      449 x Consumer Items/Pyrophyllite        9,822cr vs   28,537cr, <1 hr vs 1 hr
  Unload at Puppis Sector UO-R b4-0/Democracy Space Station (4ls, Pad:L, Plt:N, Flc:N, Ody:N, Shp:Y, Out:Y) => Gain 20,491,637cr (18,834.2cr/ton) => 404,164,533cr
  Load from Puppis Sector UO-R b4-0/Democracy Space Station (4ls, Pad:L, Plt:N, Flc:N, Ody:N, Shp:Y, Out:Y):
     1088 x Legal Drugs/Agronomic Treatment      452cr vs   28,495cr, 1 hr vs 2 hrs
  Unload at Tionisla/Ing Ring (576ls, Pad:L, Plt:N, Flc:N, Ody:N, Shp:Y, Out:Y) => Gain 30,510,784cr (28,043cr/ton) => 434,675,317cr
  ----------------------------------------------------------------------------
Finish at Tionisla/Ing Ring (576ls, Pad:L, Plt:N, Flc:N, Ody:N, Shp:Y, Out:Y) gaining 64,675,317cr (19,814cr/ton) => est 434,675,317cr total
```