### PR TITLE
chore: tradecalc touch-up

### DIFF
--- a/tradedangerous/commands/run_cmd.py
+++ b/tradedangerous/commands/run_cmd.py
@@ -1319,11 +1319,11 @@ def run(results, cmdenv, tdb):
             routes.sort()
             if pruneMod and hopNo + 1 >= cmdenv.pruneHops and len(routes) > 10:
                 crop = int(len(routes) * pruneMod)
-                routes = routes[:-crop]
+                routes[:] = routes[:-crop]
                 cmdenv.NOTE("Pruned {} origins", crop)
             
             if cmdenv.maxRoutes and len(routes) > cmdenv.maxRoutes:
-                routes = routes[:cmdenv.maxRoutes]
+                routes[:] = routes[:cmdenv.maxRoutes]
         
         if cmdenv.progress:
             extra = ""
@@ -1368,31 +1368,32 @@ def run(results, cmdenv, tdb):
                     .format(hopNo + 1)
                 )
                 break
-            if hopNo == 0:
-                if cmdenv.origPlace and len(routes) == 1:
-                    errText = (
-                        "No profitable buyers found for the goods at {}.\n"
+
+            if cmdenv.origPlace and len(routes) == 1:
+                errText = (
+                    "No profitable buyers found for the goods at {}.\n"
+                    "\n"
+                    "You may want to try:\n"
+                    "  {} local \"{}\" --ly {} -vv --stations --trading"
+                    .format(
+                        routes[0].lastStation.name(),
+                        sys.argv[0], cmdenv.origPlace.system.name(),
+                        cmdenv.maxJumpsPer * cmdenv.maxLyPer,
+                    )
+                )
+                if isinstance(cmdenv.origPlace, Station):
+                    errText += (
                         "\n"
-                        "You may want to try:\n"
-                        "  {} local \"{}\" --ly {} -vv --stations --trading"
+                        "or:\n"
+                        "  {} market \"{}\" --sell -vv"
                         .format(
-                            routes[0].lastStation.name(),
-                            sys.argv[0], cmdenv.origPlace.system.name(),
-                            cmdenv.maxJumpsPer * cmdenv.maxLyPer,
+                            sys.argv[0], cmdenv.origPlace.name(),
                         )
                     )
-                    if isinstance(cmdenv.origPlace, Station):
-                        errText += (
-                            "\n"
-                            "or:\n"
-                            "  {} market \"{}\" --sell -vv"
-                            .format(
-                                sys.argv[0], cmdenv.origPlace.name(),
-                            )
-                        )
-                    raise NoDataError(errText)
-        
-        routes = newRoutes
+                raise NoDataError(errText)
+            raise NoDataError("Unable to find any profitable buyers for first hop.")
+    
+        routes[:] = newRoutes
         if routes and goalSystem:
             # Promote the winning route to the top of the list
             # while leaving the remainder of the list intact

--- a/tradedangerous/plugins/__init__.py
+++ b/tradedangerous/plugins/__init__.py
@@ -8,7 +8,13 @@ if typing.TYPE_CHECKING:
     from tradedangerous import TradeDB, TradeEnv
 
 
-parent_name = '.'.join(__name__.split('.')[:-1])
+__all__ = [
+    'PluginException',
+    'PluginBase',
+    'ImportPluginBase',
+    'load',
+]
+
 
 class PluginException(Exception):
     """

--- a/tradedangerous/tradecalc.py
+++ b/tradedangerous/tradecalc.py
@@ -218,11 +218,15 @@ class Route:
     def __eq__(self, rhs):
         return self.score == rhs.score and len(self.jumps) == len(rhs.jumps)
 
+    def debug_text(self, colorize) -> str:
+        lhs = colorize("cyan", self.firstStation.name())
+        rhs = colorize("blue", self.lastStation.name())
+        return f"{lhs} (#{self.firstStation.ID}) -> {rhs} (#{self.lastStation.ID})"
+
     def text(self, colorize) -> str:
-        return "%s -> %s" % (
-            colorize("cyan", self.firstStation.name()),
-            colorize("blue", self.lastStation.name()),
-        )
+        lhs = colorize("cyan", self.firstStation.name())
+        rhs = colorize("blue", self.lastStation.name())
+        return f"{lhs} -> {rhs}"
 
     def detail(self, tdenv):
         """
@@ -586,13 +590,13 @@ class TradeCalc:
         # ---------- Core/Engine path (NO Session; NO ORM entities) ----------
         columns = (
             "station_id, item_id, "
-            "demand_price, demand_units, demand_level, "
-            "supply_price, supply_units, supply_level, "
+            "CASE WHEN demand_units >= :mindemand THEN demand_price ELSE 0 END AS fx_demand_price, demand_units, demand_level, "
+            "CASE WHEN supply_units >= :minsupply THEN supply_price ELSE 0 END AS fx_supply_price, supply_units, supply_level, "
             "modified"
         )
 
-        where_clauses = []
-        params = {}
+        where_clauses = ["fx_demand_price > 0 OR fx_supply_price > 0"]
+        params = {"mindemand": minDemand or 1, "minsupply": minSupply or 1}
 
         # Age cutoff (if provided in env)
         if tdenv.maxAge:
@@ -649,15 +653,13 @@ class TradeCalc:
 
                 # Buying map (demand side)
                 if d_price and d_price > 0:
-                    if not minDemand or (d_units or 0) >= minDemand:
-                        demand[stnID].append((itmID, d_price, d_units or 0, d_level, ageS))
-                        dmdCount += 1
+                    demand[stnID].append((itmID, d_price, d_units or 0, d_level, ageS))
+                    dmdCount += 1
 
                 # Selling map (supply side)
-                if s_price and s_price > 0 and s_units:
-                    if not minSupply or s_units >= minSupply:
-                        supply[stnID].append((itmID, s_price, s_units, s_level, ageS))
-                        supCount += 1
+                if s_price and s_price > 0:
+                    supply[stnID].append((itmID, s_price, s_units, s_level, ageS))
+                    supCount += 1
 
                 # Calling 'time.time()' is *very* expensive, so only do it every so many rows
                 # but the == 1 means that we'll do it for the very first row too.
@@ -888,10 +890,12 @@ class TradeCalc:
         if not srcSelling:
             srcSelling = self.stationsSelling.get(srcStation.ID, None)
             if not srcSelling:
+                self.tdenv.DEBUG2("^- source not selling anything")
                 return None
 
         dstBuying = self.stationsBuying.get(dstStation.ID, None)
         if not dstBuying:
+            self.tdenv.DEBUG2("^- dest not buying anything")
             return None
 
         minGainCr = max(1, self.tdenv.minGainPerTon or 1)
@@ -1076,7 +1080,8 @@ class TradeCalc:
         getSelling = self.stationsSelling.get
     
         for route_no, route in enumerate(routes):
-            tdenv.DEBUG1("Route = {}", route.text(lambda x, y: y))
+            if tdenv.debug > 0:
+                tdenv.DEBUG1("Route = {}", route.debug_text(lambda x, y: y))
     
             srcStation = route.lastStation
             startCr = credits + int(route.gainCr * safetyMargin)
@@ -1139,8 +1144,8 @@ class TradeCalc:
                         "->".join(jump.text() for jump in dest.via),
                         dest.distLy,
                     )
-                    return True
-                stations = (d for d in stations if annotate(d))
+                    return dest
+                stations = (annotate(d) for d in stations)
     
             for dest in stations:
                 dstStation = dest.station

--- a/tradedangerous/tradedb.py
+++ b/tradedangerous/tradedb.py
@@ -172,6 +172,9 @@ class System:
         self.addedID = addedID or 0
         self.stations: list['Station'] = []
         self._rangeCache = None
+
+    def __repr__(self) -> str:
+        return f"<System ID={self.ID} dbname='{self.dbname}' pos=({self.posX},{self.posY},{self.posZ})>"
     
     @property
     def system(self) -> 'System':
@@ -270,6 +273,9 @@ class Station:
         self.itemCount = itemCount
         self.dataAge = dataAge
         system.stations += [self]
+
+    def __repr__(self) -> str:
+        return f"<Station ID={self.ID} dbname='{self.dbname}' system_id={self.system.ID} system='{self.system.dbname}'>"
     
     def name(self, detail: int = 0) -> str:  # pylint: disable=unused-argument
         return f"{self.system.dbname}/{self.dbname}"


### PR DESCRIPTION
chore: increase debug tracing of route calculation, opt: trivial improvements to performance of route calculation
feat: trade run --demand and --supply now reduce the amount of trade-rows viewed while calculating a route (caveat: this can cause products to appear unavailable if used too aggressively, which it did anyway, but I found the way it concluded that much faster made me think it wasn't working) chore: repr for TradeDB System and Station
- I know, we're deprecating these, but that makes it even more helpful to be able to *see* them in rich/debugging for now.

fix: run: handle finding no trades to route better
- I was noticing an error/exception when no routes-with-trades were found when using certain filters (--demand/--supply) or using an overly-aggressive --gpt (I may have typoed 10000, no you typoed)
- Also, using routes[:] acts as an in-place truncate/crop/reassignment and reduces memory pressure a little.
- This is mostly cosmetic, any perf gains are negligible.

chore: missing __all__ from plugins/__init__