### PR TITLE
chore: reseat max-link-ly into tradeenv

### DIFF
--- a/tradedangerous/commands/__init__.py
+++ b/tradedangerous/commands/__init__.py
@@ -26,6 +26,7 @@ from . import trade_cmd
 from . import update_cmd
 
 from tradedangerous import version
+from tradedangerous.tradeenv import ENV_DEFAULTS
 
 
 thismodule = sys.modules[__name__]
@@ -224,7 +225,7 @@ class CommandIndex:
         stdArgs.add_argument('--link-ly', '-L',
                     help = 'Maximum lightyears between systems to be considered linked.',
                     type = float,
-                    default = None, dest = 'maxSystemLinkLy',
+                    default = ENV_DEFAULTS['maxSystemLinkLy'], dest = 'maxSystemLinkLy',
                 )
         
         fromfilePath = _findFromFile(cmdModule.name)

--- a/tradedangerous/commands/buy_cmd.py
+++ b/tradedangerous/commands/buy_cmd.py
@@ -277,7 +277,7 @@ def run(results, cmdenv, tdb):
     # System-based search
     nearSystem = cmdenv.nearSystem
     if nearSystem:
-        maxLy = cmdenv.maxLyPer or tdb.maxSystemLinkLy
+        maxLy = cmdenv.maxLyPer or cmdenv.maxSystemLinkLy
         results.summary.near = nearSystem
         results.summary.ly = maxLy
         distanceFn = nearSystem.distanceTo

--- a/tradedangerous/commands/local_cmd.py
+++ b/tradedangerous/commands/local_cmd.py
@@ -1,13 +1,15 @@
+from __future__ import annotations
+from itertools import chain
+
 from .commandenv import ResultRow
+from .exceptions import NoDataError
 from .parsing import (
     ParseArgument, PadSizeArgument, MutuallyExclusiveGroup, NoPlanetSwitch,
     PlanetaryArgument, FleetCarrierArgument, OdysseyArgument, BlackMarketSwitch,
     ShipyardSwitch, OutfittingSwitch, RearmSwitch, RefuelSwitch, RepairSwitch,
 )
-from ..formatting import RowFormat, ColumnFormat, max_len
-from itertools import chain
-from ..tradedb import TradeDB
-from ..tradeexcept import TradeException
+from tradedangerous import TradeDB
+from tradedangerous.formatting import RowFormat, ColumnFormat, max_len
 
 
 ######################################################################
@@ -28,7 +30,7 @@ arguments = [
 switches = [
     ParseArgument('--ly',
             help='Maximum light years from system.',
-            dest='maxLyPer',
+            dest='ly',
             metavar='N.NN',
             type=float,
             default=None,
@@ -65,9 +67,8 @@ def run(results, cmdenv, tdb):
     tdb = cmdenv.tdb
     srcSystem = cmdenv.nearSystem
     
-    ly = cmdenv.maxLyPer
-    if ly is None:
-        ly = tdb.maxSystemLinkLy
+    # Allow the user to say '0' for system-only
+    ly = cmdenv.ly if cmdenv.ly is not None else cmdenv.maxSystemLinkLy
     
     results.summary = ResultRow()
     results.summary.near = srcSystem
@@ -145,17 +146,14 @@ def run(results, cmdenv, tdb):
     
     return results
 
-######################################################################
-# Transform result set into output
 
 def render(results, cmdenv, tdb):
+    """ render transforms a result set into output for the CLI. """
     if not results or not results.rows:
-        raise TradeException(
-            "No systems found within {}ly of {}."
-            .format(results.summary.ly, results.summary.near.name())
-        )
+        distance, origin = results.summary.ly, results.summary.near.name()
+        raise NoDataError(f"No suitable systems found within {distance}ly of {origin}.")
     
-    # Compare system names so we can tell
+    # Compare name lengths for formatting
     maxSysLen = max_len(results.rows, key=lambda row: row.system.name())
     
     sysRowFmt = RowFormat().append(

--- a/tradedangerous/commands/nav_cmd.py
+++ b/tradedangerous/commands/nav_cmd.py
@@ -70,7 +70,7 @@ def run(results, cmdenv, tdb):
     if isinstance(dstSystem, Station):
         dstSystem = dstSystem.system
     
-    maxLyPer = cmdenv.maxLyPer or tdb.maxSystemLinkLy
+    maxLyPer = cmdenv.maxLyPer or cmdenv.maxSystemLinkLy
     
     cmdenv.DEBUG0("Route from {} to {} with max {}ly per jump.",
                     srcSystem.name(), dstSystem.name(), maxLyPer)

--- a/tradedangerous/commands/olddata_cmd.py
+++ b/tradedangerous/commands/olddata_cmd.py
@@ -135,7 +135,7 @@ def run(results, cmdenv, tdb):
     
     # Bounding box for near (keeps scan small, mirrors original)
     if nearSys:
-        maxLy = cmdenv.maxLyPer or tdb.maxSystemLinkLy
+        maxLy = cmdenv.maxLyPer or cmdenv.maxSystemLinkLy
         # Bounding box predicate
         stmt = stmt.where(
             sys_tbl.c.pos_x.between(nearSys.posX - maxLy, nearSys.posX + maxLy),

--- a/tradedangerous/commands/sell_cmd.py
+++ b/tradedangerous/commands/sell_cmd.py
@@ -155,7 +155,7 @@ def run(results, cmdenv, tdb: TradeDB):
     # System-based search
     nearSystem = cmdenv.nearSystem
     if nearSystem:
-        maxLy = cmdenv.maxLyPer or tdb.maxSystemLinkLy
+        maxLy = cmdenv.maxLyPer or cmdenv.maxSystemLinkLy
         results.summary.near = nearSystem
         results.summary.ly = maxLy
         distanceFn = nearSystem.distanceTo

--- a/tradedangerous/plugins/edcd_plug.py
+++ b/tradedangerous/plugins/edcd_plug.py
@@ -363,7 +363,7 @@ class ImportPlugin(ImportPluginBase):
         
         # Ensure the cache is built and reloaded.
         tdb.reloadCache()
-        tdb.load(maxSystemLinkLy=tdenv.maxSystemLinkLy)
+        tdb.load()
         
         self.download_fdevids()
         

--- a/tradedangerous/tradedb.py
+++ b/tradedangerous/tradedb.py
@@ -635,7 +635,7 @@ class TradeDB:
         # --- Initial load ---
         if load:
             self.reloadCache()
-            self.load(maxSystemLinkLy=tdenv.maxSystemLinkLy)
+            self.load()
     
     # ------------------------------------------------------------------
     # Legacy compatibility dataPath shim
@@ -1942,7 +1942,7 @@ class TradeDB:
         
         if maxJumps is None:
             maxJumps = sys.maxsize
-        maxLyPer = maxLyPer or self.maxSystemLinkLy
+        maxLyPer = maxLyPer or self.tdenv.maxSystemLinkLy
         if avoidPlaces is None:
             avoidPlaces = ()
         
@@ -2200,7 +2200,7 @@ class TradeDB:
             self.engine = None
         # Keep engine + Session references so reloadCache/buildCache can reuse them
     
-    def load(self, maxSystemLinkLy=None):
+    def load(self) -> None:
         """
             Populate/re-populate this instance of TradeDB with data.
             WARNING: This will orphan existing records you have
@@ -2219,10 +2219,9 @@ class TradeDB:
         self._loadItems()
         self.tdenv.DEBUG0("Data load took {:.3f}s", time.time() - started)
         
-        # Calculate the maximum distance anyone can jump so we can constrain
-        # the maximum "link" between any two stars.
-        msll = maxSystemLinkLy or self.tdenv.maxSystemLinkLy or 30
-        self.maxSystemLinkLy = msll
+    @property
+    def max_link_ly(self) -> float | int:
+        return self.tdenv.maxSystemLinkLy
     
     ############################################################
     # General purpose static methods.

--- a/tradedangerous/tradeenv.py
+++ b/tradedangerous/tradeenv.py
@@ -104,10 +104,14 @@ class RichColorTheme(BasicRichColorTheme):
 
 class BaseConsoleIOMixin:
     """ Base mixin for running output through rich. """
-    console: Console
-    stderr:  Console
-    theme:   BaseColorTheme
-    quiet:   int
+    color:    bool
+    console:  Console
+    debug:    int
+    detail:   int
+    encoding: str
+    quiet:    int
+    stderr:   Console
+    theme:    BaseColorTheme
     
     def uprint(self, *args: Any, stderr: bool = False, style: str | None = None, **kwargs: Any) -> None:
         """
@@ -169,6 +173,7 @@ ENV_DEFAULTS: dict[str, Any] = {
         'cwDir': os.getcwd(),
         'console': CONSOLE,
         'stderr':  STDERR,
+        'maxSystemLinkLy': 64.0,
     }
 
 
@@ -188,25 +193,21 @@ class TradeEnv(Utf8SafeConsoleIOMixin):
         To print debug lines, use DEBUG<N>, e.g. DEBUG0, which takes a format() string and parameters, e.g.
             DEBUG1("hello, {world}{}", "!", world="world")
         
-        is equivalent to:
-            if tdenv.debug >= 1:
-                print("#hello, {world}{}".format("!", world="world"))
+        is similar to:
+            arg0, arg1 = "!", "world"
+            if tdenv.debug > 1:
+                tdenv.console.print("# hello, {arg1}{}".format(arg0=arg0, arg1=arg1))
         
         Use "NOTE" to print remarks which can be disabled with -q.
     """
-    
-    debug: int
-    detail: int
-    color: bool
-    theme: BaseColorTheme
-    persist: bool
-    dataDir: str
     csvDir: str
-    tmpDir: str
-    templateDir: str
     cwDir: str
-    console: Console
-    stderr: Console
+    dataDir: str
+    maxSystemLinkLy: float
+    persist: bool
+    templateDir: str
+    theme: BaseColorTheme
+    tmpDir: str
     
     encoding = sys.stdout.encoding
     

--- a/tradedangerous/tradeenv.pyi
+++ b/tradedangerous/tradeenv.pyi
@@ -64,10 +64,15 @@ class RichColorTheme(BasicRichColorTheme):
 
 
 class BaseConsoleIOMixin:
-    console: Console
-    stderr: Console
-    theme: BaseColorTheme
-    quiet: int
+    color:    bool
+    console:  Console
+    debug:    int
+    detail:   int
+    encoding: str
+    quiet:    int
+    stderr:   Console
+    theme:    BaseColorTheme
+    
     def uprint(self, *args: Any, stderr: bool = False, style: str | None = None, **kwargs: Any) -> None: ...
 
 
@@ -76,22 +81,15 @@ class NonUtf8ConsoleIOMixin(BaseConsoleIOMixin):
 
 
 class TradeEnv(BaseConsoleIOMixin):
-    debug: int
-    detail: int
-    color: bool
-    theme: BaseColorTheme
-    persist: bool
-    dataDir: str
     csvDir: str
-    tmpDir: str
-    templateDir: str
     cwDir: str
-    console: Console
-    stderr: Console
-    quiet: int
-    
-    encoding: str
-    
+    dataDir: str
+    maxSystemLinkLy: float
+    persist: bool
+    templateDir: str
+    theme: BaseColorTheme
+    tmpDir: str
+
     def __init__(self, properties: dict[str, Any] | argparse.Namespace | None = None, **kwargs: Any) -> None: ...
     
     # Dynamically-generated log methods with full type hints


### PR DESCRIPTION
currently it's in tradedb which is not where it should be and would be an annoyance for working with TradeORM.

This also gives it a new default of 64, and a default that's in the same place as other tradeenv parameters...

chore: make maxSystemLinkLy a formal property of TradeEnv

chore: get maxSystemLinkLy from tradeenv, not tradedb