### PR TITLE
feat: transition 'local' command to tradeorm for speed

### DIFF
--- a/tradedangerous/commands/local_cmd.py
+++ b/tradedangerous/commands/local_cmd.py
@@ -1,15 +1,28 @@
 from __future__ import annotations
 from itertools import chain
+import datetime
+import typing
+
+from tradedangerous import TradeORM
+from tradedangerous.tradeorm import PADSIZE_LABELS, TRISTATE_LABELS
+from tradedangerous.db.orm_models import Station, System
+from tradedangerous.formatting import RowFormat, ColumnFormat, max_len
 
 from .commandenv import ResultRow
-from .exceptions import NoDataError
+from .exceptions import CommandLineError, NoDataError
 from .parsing import (
     ParseArgument, PadSizeArgument, MutuallyExclusiveGroup, NoPlanetSwitch,
     PlanetaryArgument, FleetCarrierArgument, OdysseyArgument, BlackMarketSwitch,
     ShipyardSwitch, OutfittingSwitch, RearmSwitch, RefuelSwitch, RepairSwitch,
 )
-from tradedangerous import TradeDB
-from tradedangerous.formatting import RowFormat, ColumnFormat, max_len
+
+from sqlalchemy import select, and_, not_
+from sqlalchemy.orm import aliased, selectinload, with_loader_criteria
+
+
+if typing.TYPE_CHECKING:
+    from typing import Any
+    from .commandenv import CommandEnv, CommandResults
 
 
 ######################################################################
@@ -18,7 +31,8 @@ from tradedangerous.formatting import RowFormat, ColumnFormat, max_len
 name='local'
 help='Calculate local systems.'
 epilog="See also the 'station' sub-command."
-wantsTradeDB=True
+wantsTradeDB=False
+wantsTradeORM=True
 arguments = [
     ParseArgument(
             'near',
@@ -27,7 +41,7 @@ arguments = [
             metavar='SYSTEMNAME',
     ),
 ]
-switches = [
+switches: list[Any] = [
     ParseArgument('--ly',
             help='Maximum light years from system.',
             dest='ly',
@@ -51,6 +65,19 @@ switches = [
                  'a market.',
             action='store_true',
     ),
+    ParseArgument('--ls-max',
+        help = 'Only consider stations upto this many ls from their star.',
+        metavar = 'LS',
+        dest = 'maxLs',
+        type = int,
+        default = 0,
+    ),
+    ParseArgument('--limit', '-n',
+                  help='Limit output to the first N results. (0 = no limit)',
+                  dest='limit',
+                  type=int,
+                  default=0,
+    ),
     BlackMarketSwitch(),
     ShipyardSwitch(),
     OutfittingSwitch(),
@@ -61,87 +88,112 @@ switches = [
 
 ######################################################################
 # Perform query and populate result set
+# Return the result set to render or False.
 
-def run(results, cmdenv, tdb):
-    cmdenv = results.cmdenv
-    tdb = cmdenv.tdb
-    srcSystem = cmdenv.nearSystem
+def run(results: CommandResults, cmdenv: CommandEnv, tdb: TradeORM | None) -> CommandResults | bool:
+    cmdenv = results.cmdenv  # Needs clarification
+    tdb = TradeORM(tdenv=cmdenv)
+    # Show the stations if present
+    show_stations: bool = bool(cmdenv.detail)
+    # Only match systems with stations
+    need_stations: bool = bool(getattr(cmdenv, "stations", False))
+
+    try:
+        origin = tdb.lookup_system(cmdenv.near)
+    except LookupError as e:
+        raise CommandLineError(str(e))
     
+    if not origin:
+        raise CommandLineError(f"Unknown system: {cmdenv.near}")
+
     # Allow the user to say '0' for system-only
     ly = cmdenv.ly if cmdenv.ly is not None else cmdenv.maxSystemLinkLy
     
     results.summary = ResultRow()
-    results.summary.near = srcSystem
+    results.summary.near = origin
     results.summary.ly = ly
     results.summary.stations = 0
-    
-    distances = { srcSystem: 0.0 }
-    
-    # Calculate the bounding dimensions
-    for destSys, dist in tdb.genSystemsInRange(srcSystem, ly):
-        distances[destSys] = dist
-    
-    showStations = cmdenv.detail
-    wantStations = cmdenv.stations
-    padSize = cmdenv.padSize
-    planetary = cmdenv.planetary
-    fleet = cmdenv.fleet
-    odyssey = cmdenv.odyssey
-    wantNoPlanet = cmdenv.noPlanet
-    wantTrading = cmdenv.trading
-    wantShipYard = cmdenv.shipyard
-    wantBlackMarket = cmdenv.blackMarket
-    wantOutfitting = cmdenv.outfitting
-    wantRearm = cmdenv.rearm
-    wantRefuel = cmdenv.refuel
-    wantRepair = cmdenv.repair
-    
-    def station_filter(stations):
-        for station in stations:
-            if wantNoPlanet and station.planetary != 'N':
-                continue
-            if wantTrading and not station.isTrading:
-                continue
-            if wantBlackMarket and station.blackMarket != 'Y':
-                continue
-            if wantShipYard and station.shipyard != 'Y':
-                continue
-            if padSize and not station.checkPadSize(padSize):
-                continue
-            if planetary and not station.checkPlanetary(planetary):
-                continue
-            if fleet and not station.checkFleet(fleet):
-                continue
-            if odyssey and not station.checkOdyssey(odyssey):
-                continue
-            if wantOutfitting and station.outfitting != 'Y':
-                continue
-            if wantRearm and station.rearm != 'Y':
-                continue
-            if wantRefuel and station.refuel != 'Y':
-                continue
-            if wantRepair and station.repair != 'Y':
-                continue
-            yield station
-    
-    for (system, dist) in sorted(distances.items(), key=lambda x: x[1]):
-        if showStations or wantStations:
-            stations = []
-            for (station) in station_filter(system.stations):
-                stations.append(
-                    ResultRow(
-                        station=station,
-                        age=station.itemDataAgeStr,
-                    )
-                )
-            if not stations and wantStations:
-                continue
-        
+    results.summary.limit = max(cmdenv.limit, 0)
+    results.summary.show_stations = show_stations
+
+    candidate = aliased(System, name="candidate")
+    # distance clamp. if this is too slow, we might
+    # want to do a simple range <= x-x <= range, first.
+    dx = candidate.pos_x - origin.pos_x
+    dy = candidate.pos_y - origin.pos_y
+    dz = candidate.pos_z - origin.pos_z
+    range_sq: float = float((ly or 0.0) ** 2)
+    distance_sq = ((dx * dx) + (dy * dy) + (dz * dz)).label("distance_sq")
+
+    query = (
+        select(candidate, distance_sq)
+        .where(distance_sq <= range_sq)
+        .order_by(distance_sq)
+    )
+
+    station_filters: list[Any] = []
+
+    if show_stations or need_stations:
+        # apply filter rules
+        if cmdenv.trading:
+            station_filters.append(Station.market == 'Y')
+        if cmdenv.blackMarket:
+            station_filters.append(Station.blackmarket == 'Y')
+        if cmdenv.maxLs:
+            station_filters.append(and_(Station.ls_from_star > 0, Station.ls_from_star <= cmdenv.maxLs))
+        if cmdenv.outfitting:
+            station_filters.append(Station.outfitting == 'Y')
+
+        if cmdenv.shipyard:
+            station_filters.append(Station.shipyard == 'Y')
+
+        if cmdenv.rearm:
+            station_filters.append(Station.rearm == 'Y')
+        if cmdenv.refuel:
+            station_filters.append(Station.refuel == 'Y')
+        if cmdenv.repair:
+            station_filters.append(Station.repair == 'Y')
+
+        if cmdenv.padSize:
+            station_filters.append(Station.max_pad_size.in_(list(cmdenv.padSize)))
+        if cmdenv.noPlanet:
+            station_filters.append(not_(Station.is_planetary))
+        elif cmdenv.planetary:
+            station_filters.append(Station.planetary.in_(list(cmdenv.planetary)))
+        elif cmdenv.odyssey:
+            station_filters.append(Station.odyssey.in_(list(cmdenv.odyssey)))
+
+        if cmdenv.fleet == 'Y':
+            station_filters.append(Station.is_fleet_carrier)
+        elif cmdenv.fleet == 'N':
+            station_filters.append(not_(Station.is_fleet_carrier))
+
+    if station_filters:
+        combined_filter = and_(*station_filters)
+        query = query.where(candidate.stations.any(combined_filter))
+        # Now, make the systems only load their stations that match the filter.
+        query = query.options(
+            selectinload(candidate.stations),
+            with_loader_criteria(Station, combined_filter, include_aliases=True),
+        )
+    elif need_stations:
+        query = query.where(candidate.stations.any())
+
+    if results.summary.limit:
+        query = query.limit(results.summary.limit)
+
+    if cmdenv.debug > 0:
+        compiled = query.compile(dialect=tdb.session.bind.dialect, compile_kwargs={"literal_binds": True})
+        cmdenv.DEBUG0("query: {}", compiled)
+
+    rows = tdb.session.execute(query).all()
+    for system, distance_sq in rows:
         row = ResultRow()
         row.system = system
-        row.dist = dist
-        row.stations = stations if showStations else []
+        row.dist = distance_sq ** 0.5
+        row.stations = []
         results.rows.append(row)
+
         results.summary.stations += len(row.stations)
     
     return results
@@ -150,94 +202,103 @@ def run(results, cmdenv, tdb):
 def render(results, cmdenv, tdb):
     """ render transforms a result set into output for the CLI. """
     if not results or not results.rows:
-        distance, origin = results.summary.ly, results.summary.near.name()
+        distance, origin = results.summary.ly, results.summary.near.name
         raise NoDataError(f"No suitable systems found within {distance}ly of {origin}.")
     
     # Compare name lengths for formatting
-    maxSysLen = max_len(results.rows, key=lambda row: row.system.name())
+    maxSysLen = max_len(results.rows, key=lambda row: row.system.name)
     
     sysRowFmt = RowFormat().append(
         ColumnFormat("System", '<', maxSysLen,
-                key=lambda row: row.system.name())
+                key=lambda row: row.system.name)
     ).append(
         ColumnFormat("Dist", '>', '7', '.2f',
                 key=lambda row: row.dist)
     )
     
-    showStations = cmdenv.detail
-    if showStations:
+    if results.summary.show_stations:
+        now = datetime.datetime.now(tz=datetime.timezone.utc)
         maxStnLen = max_len(
-            chain.from_iterable(row.stations for row in results.rows),
-            key=lambda row: row.station.dbname
+            chain.from_iterable(row.system.stations for row in results.rows),
+            key=lambda stn: stn.name
         )
         maxLsLen = max_len(
-            chain.from_iterable(row.stations for row in results.rows),
-            key=lambda row: row.station.distFromStar()
+            chain.from_iterable(row.system.stations for row in results.rows),
+            key=lambda stn: f"{int(stn.ls_from_star or 0):n}"
         )
         maxLsLen = max(maxLsLen, 5)
         stnRowFmt = RowFormat(prefix='  /  ').append(
-                ColumnFormat("Station", '.<', maxStnLen + 2,
-                    key=lambda row: row.station.dbname)
+                ColumnFormat("Station", '<', maxStnLen + 2,
+                    key=lambda stn: stn.name)
         ).append(
-                ColumnFormat("StnLs", '>', maxLsLen,
-                    key=lambda row: row.station.distFromStar())
-        ).append(
-                ColumnFormat("Age/days", '>', 7,
-                        key=lambda row: row.age)
+                ColumnFormat("StnLs", '>', maxLsLen, "n",
+                    key=lambda stn: int(stn.ls_from_star or 0))
         ).append(
                 ColumnFormat("Mkt", '>', '3',
-                    key=lambda row: TradeDB.marketStates[row.station.market])
+                    key=lambda stn: TRISTATE_LABELS[stn.market])
         ).append(
                 ColumnFormat("BMk", '>', '3',
-                    key=lambda row: TradeDB.marketStates[row.station.blackMarket])
+                    key=lambda stn: TRISTATE_LABELS[stn.blackmarket])
         ).append(
                 ColumnFormat("Shp", '>', '3',
-                    key=lambda row: TradeDB.marketStates[row.station.shipyard])
+                    key=lambda stn: TRISTATE_LABELS[stn.shipyard])
         ).append(
                 ColumnFormat("Out", '>', '3',
-                    key=lambda row: TradeDB.marketStates[row.station.outfitting])
+                    key=lambda stn: TRISTATE_LABELS[stn.outfitting])
         ).append(
                 ColumnFormat("Arm", '>', '3',
-                    key=lambda row: TradeDB.marketStates[row.station.rearm])
+                    key=lambda stn: TRISTATE_LABELS[stn.rearm])
         ).append(
                 ColumnFormat("Ref", '>', '3',
-                    key=lambda row: TradeDB.marketStates[row.station.refuel])
+                    key=lambda stn: TRISTATE_LABELS[stn.refuel])
         ).append(
                 ColumnFormat("Rep", '>', '3',
-                    key=lambda row: TradeDB.marketStates[row.station.repair])
+                    key=lambda stn: TRISTATE_LABELS[stn.repair])
         ).append(
                 ColumnFormat("Pad", '>', '3',
-                    key=lambda row: TradeDB.padSizes[row.station.maxPadSize])
+                    key=lambda stn: PADSIZE_LABELS[stn.max_pad_size])
         ).append(
                 ColumnFormat("Plt", '>', '3',
-                    key=lambda row: TradeDB.planetStates[row.station.planetary])
+                    key=lambda stn: TRISTATE_LABELS[stn.planetary])
         ).append(
                 ColumnFormat("Flc", '>', '3',
-                    key=lambda row: TradeDB.fleetStates[row.station.fleet])
+                    key=lambda stn: TRISTATE_LABELS[stn.fleet_carrier])
         ).append(
                 ColumnFormat("Ody", '>', '3',
-                    key=lambda row: TradeDB.odysseyStates[row.station.odyssey])
+                    key=lambda stn: TRISTATE_LABELS[stn.odyssey])
         )
         if cmdenv.detail > 1:
+            stnRowFmt = stnRowFmt.append(
+                ColumnFormat("Age/days", '>', 7,
+                            key=lambda stn: (round((now - stn.modified).total_seconds() / 86400, 2)) if stn.modified else "n/a")
+            )
             stnRowFmt.append(
                 ColumnFormat("Itms", ">", 4,
-                    key=lambda row: row.station.itemCount)
+                    key=lambda stn: len(stn.items))
             )
     
     cmdenv.DEBUG0(
         "Systems within {ly:<5.2f}ly of {sys}.\n",
-        sys=results.summary.near.name(),
+        sys=results.summary.near.name,
         ly=results.summary.ly,
     )
     
     if not cmdenv.quiet:
         heading, underline = sysRowFmt.heading()
-        if showStations:
-            print(heading)
+        if results.summary.show_stations:
+            cmdenv.uprint(heading)
             heading, underline = stnRowFmt.heading()
-        print(heading, underline, sep='\n')
+        cmdenv.uprint(heading, underline, sep='\n')
     
     for row in results.rows:
-        print(sysRowFmt.format(row))
-        for stnRow in row.stations:
-            print(stnRowFmt.format(stnRow))
+        cmdenv.uprint(sysRowFmt.format(row))
+        if not results.summary.show_stations:
+            continue
+        stations = row.system.stations
+        truncate = results.summary.limit > 0 and len(stations) > results.summary.limit
+        if truncate:
+            stations = stations[:results.summary.limit]
+        for stnRow in stations:
+            cmdenv.uprint(stnRowFmt.format(stnRow))
+        if truncate:
+            cmdenv.uprint(f"  /  ... {len(row.system.stations) - results.summary.limit} more ...")

--- a/tradedangerous/commands/trade_cmd.py
+++ b/tradedangerous/commands/trade_cmd.py
@@ -26,6 +26,7 @@ help='Find potential trades between two given stations.'
 name='trade'
 epilog=None
 wantsTradeDB=False
+wantsTradeORM=True
 arguments = [
     ParseArgument(
         'origin',
@@ -179,8 +180,9 @@ def get_stations(cmdenv: CommandEnv, tdb: TradeORM) -> tuple[models.Station, mod
 
 ######################################################################
 # Perform query and populate result set
+# Return the result set to render or False.
 
-def run(results: CommandResults, cmdenv: CommandEnv, tdb: TradeORM | None) -> CommandResults:
+def run(results: CommandResults, cmdenv: CommandEnv, tdb: TradeORM | None = None) -> CommandResults | None:
     tdb = TradeORM(tdenv=cmdenv)
 
     # Did they specify --fill?

--- a/tradedangerous/db/orm_models.py
+++ b/tradedangerous/db/orm_models.py
@@ -18,11 +18,18 @@ from sqlalchemy import (
     text,
     Column,
     DateTime,
+    or_,
+    case,
 )
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
 from sqlalchemy.sql import expression
 from sqlalchemy.ext.compiler import compiles
+from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.types import TypeDecorator
+
+
+FLEET_CARRIER_TYPE = 24
+ODYSSEY_TYPE = 25
 
 
 # ---- Dialect-aware time utilities (moved before model usage) ----
@@ -155,6 +162,7 @@ class System(Base):
         nullable=False,
     )
     
+    @hybrid_property
     def dbname(self) -> str:
         return f"{self.name.upper()}/"
     
@@ -175,9 +183,38 @@ class Station(Base):
     station_id: Mapped[int] = mapped_column(BigInteger, primary_key=True)
     name: Mapped[str] = mapped_column(CIString(128), nullable=False)
     
+    @hybrid_property
     def dbname(self) -> str:
         return f"{self.system.name}/{self.name}"
-    
+
+    @hybrid_property
+    def is_fleet_carrier(self) -> bool:
+        return self.type_id == FLEET_CARRIER_TYPE
+
+    @hybrid_property
+    def fleet_carrier(self) -> str:
+        return 'Y' if self.type_id == FLEET_CARRIER_TYPE else 'N'
+
+    @hybrid_property
+    def is_planetary(self) -> bool:
+        return self.planetary == 'Y' or self.type_id == ODYSSEY_TYPE
+
+    @is_planetary.expression
+    def is_planetary(cls):
+        return or_(cls.planetary == 'Y', cls.type_id == ODYSSEY_TYPE)
+
+    @hybrid_property
+    def is_odyssey_planetary(self) -> bool:
+        return self.type_id == ODYSSEY_TYPE
+
+    @hybrid_property
+    def odyssey(self) -> str:
+        return 'Y' if self.type_id == ODYSSEY_TYPE else 'N'
+
+    @odyssey.expression
+    def odyssey(cls):
+        return case((cls.type_id == ODYSSEY_TYPE, 'Y'), else_='N')
+
     # type widened; cascade semantics unchanged (DELETE only)
     system_id: Mapped[int] = mapped_column(
         BigInteger,

--- a/tradedangerous/tradeorm.py
+++ b/tradedangerous/tradeorm.py
@@ -28,6 +28,23 @@ if typing.TYPE_CHECKING:
     from .db.engine import sessionmaker, Engine, Session  # type: ignore
 
 
+class NameNotFoundError(TradeException):
+    """ NameNotFoundError indicates that a string provided for a name lookup could not be matched. """
+
+
+TRISTATE_LABELS: dict[str, str] = {'?': 'Unk', 'Y': 'Yes', 'N': 'No'}
+
+MARKET_STATES:   dict[str, str] = TRISTATE_LABELS
+PLANET_STATES:   dict[str, str] = TRISTATE_LABELS
+FLEET_STATES:    dict[str, str] = TRISTATE_LABELS
+ODYSSEY_STATES:  dict[str, str] = TRISTATE_LABELS
+
+PADSIZE_LABELS:  dict[str, str] = {'?': 'Unk', 'S': 'Sml', 'M': 'Med', 'L': 'Lrg'}
+
+# A guard object we can use to determine you do not want 'default' behavior.
+_NO_DEFAULT = object()
+
+
 class TradeORM:
     DEFAULT_PATH = "data"
     DEFAULT_DB = "TradeDangerous.db"
@@ -78,24 +95,32 @@ class TradeORM:
         """ Commit the current transaction state. """
         return self.session.commit()
     
-    def lookup_station(self, name: str) -> orm.Station | None:
+    def lookup_station(self, name: str, default: orm.Station | None | object = _NO_DEFAULT) -> orm.Station | None:
         """ Use the database to lookup a station, which accepts a name that
             is either a unique station name (or partial of one), or in the
-            'system name/station name' component. If the station does not
-            match a unique station, raises an AmbiguityError
+            'system name/station name' component.
+            raises:
+              - AmbiguityError if the name can match multiple stations,
+              - ValueError if the name contains a '%',
+              - SystemNotStationError if the name matches a system
+              - NameNotFoundError if the name matches nothing and default is not specified,
+            returns:
+              - Matching station if a single match found,
+              - otherwise default if specified.
         """
         if "%" in name:
-            raise TradeException("wildcards ('%') are not supported in station names")
+            raise ValueError("wildcards ('%') are not supported in station names")
         if "/" not in name:
             if (station := self._station_lookup(name, exact=True, partial=False)):
                 return station
             if self._system_lookup(name, exact=True, partial=False):
                 raise SystemNotStationError(f'"{name}" is a system name, use "/{name}" if you meant it as a station')
             name = "/" + name
-        station: orm.Station | None = self.lookup_place(name)
+
+        station: orm.Station | None = self.lookup_place(name, default=default)
         return station
-    
-    def lookup_system(self, name: str) -> orm.System | None:
+
+    def lookup_system(self, name: str, default: orm.System | orm.Station | object | None = _NO_DEFAULT) -> orm.System | None:
         """ Use the database to lookup a system, which accepts a name that
             is either a unique system name (or partial of one), or in the
             'system name/station name' component. If the system does not
@@ -106,12 +131,12 @@ class TradeORM:
         system_name, _, _ = name.partition("/")
         if not system_name:
             raise TradeException(f"system name required for system lookup, got {name}")
-        result: orm.Station | orm.System | None = self.lookup_place(system_name)
+        result: orm.Station | orm.System | None = self.lookup_place(system_name, default=default)
         if isinstance(result, orm.Station):
-            return result.system
+            result = result.system
         return result
-    
-    def lookup_place(self, name: str) -> orm.Station | orm.System | None:
+
+    def lookup_place(self, name: str, default: orm.System | orm.Station | object | None = None) -> orm.Station | orm.System | object | None:
         """ Using a "[<system>]/[<station>]" style name, look up either a Station or a System."""
         if "%" in name:
             raise TradeException("wildcards ('%') are not supported in names")
@@ -129,7 +154,9 @@ class TradeORM:
         if sys_name:
             system = self._system_lookup(sys_name)
             if not system:
-                raise TradeException(f"unknown system: {sys_name}")
+                if default is not _NO_DEFAULT:
+                    return default
+                raise NameNotFoundError(f"unknown system: {sys_name}")
             if not stn_name:
                 return system
             
@@ -148,8 +175,10 @@ class TradeORM:
             return results[0]
         
         station = self._station_lookup(stn_name, exact=False)
-        return station
-    
+        if not station and default is not _NO_DEFAULT:
+            return station
+        raise NameNotFoundError(f"could not lookup place: {name}")
+
     def _system_lookup(self, name: str, *, exact: bool = True, partial: bool = True) -> orm.System | None:
         """ Look up a model by exact name match. """
         assert exact or partial, "at least one of exact or partial must be True"


### PR DESCRIPTION
DRAFT:

Transitions "local" command to a new pattern that makes it much more responsive, adding a few extra options and some cleanup.

new "--limit" option:
<img width="694" height="331" alt="image" src="https://github.com/user-attachments/assets/e080c0c6-d61b-4ae9-891c-1fe266825c39" />

systems with stations that are not fleet carriers within 8 ly:
<img width="492" height="292" alt="image" src="https://github.com/user-attachments/assets/90d4f3c5-5e66-4005-8dbd-f71e7554e2fd" />

within 6 ly of reorte, systems + stations that are trading and known to be within 300 ls of arrival point, non-planetary, and non-fleet carrier:
<img width="684" height="296" alt="image" src="https://github.com/user-attachments/assets/2410c134-75d8-4638-ac48-34e171e893fd" />

stations in "Rhea" (ly=0) which aren't planetary:
<img width="678" height="290" alt="image" src="https://github.com/user-attachments/assets/513e0e51-6db0-4dad-b59a-8e918335806d" />

