### PR TITLE
fix: missing import of TradeDB could block run commands

### DIFF
--- a/tradedangerous/commands/run_cmd.py
+++ b/tradedangerous/commands/run_cmd.py
@@ -5,7 +5,7 @@ import sys
 import time
 import typing
 
-from tradedangerous.tradedb import describeAge, Station, System
+from tradedangerous.tradedb import describeAge, TradeDB, Station, System
 from tradedangerous.tradecalc import NoHopsError, Route, TradeCalc, UserAbortedRun
 
 from .commandenv import ResultRow
@@ -17,7 +17,7 @@ from .parsing import (
 )
 
 if typing.TYPE_CHECKING:
-    from tradedangerous import TradeDB, TradeEnv
+    from tradedangerous import TradeEnv
 
 
 ######################################################################


### PR DESCRIPTION
I'm not sure how the 'run' command was working without this; the import had gotten moved into the typing check.

without:
```
Win|pwsh> python trade.py run --ly 64 --cr 1500m --cap 1070 --from alrai --empty 70 --start-jumps 1 --fc=n --pad ml --age=3 --hops 4 --to shinrartadez
Searching for quality trades. This may take a few minutes. Please be patient.
Traceback (most recent call last):
  File "G:\Elite\Trade-Dangerous\trade.py", line 47, in <module>
    cli.main(sys.argv)
  File "G:\Elite\Trade-Dangerous\tradedangerous\cli.py", line 66, in main
    trade(argv)
  File "G:\Elite\Trade-Dangerous\tradedangerous\cli.py", line 126, in trade
    results = cmdenv.run(tdb)
  File "G:\Elite\Trade-Dangerous\tradedangerous\commands\commandenv.py", line 156, in run
    return self._cmd.run(results, self, tdb)
  File "G:\Elite\Trade-Dangerous\tradedangerous\commands\run_cmd.py", line 1234, in run
    validateRunArguments(tdb, cmdenv, calc)
  File "G:\Elite\Trade-Dangerous\tradedangerous\commands\run_cmd.py", line 968, in validateRunArguments
    checkDestinations(tdb, cmdenv, calc)
  File "G:\Elite\Trade-Dangerous\tradedangerous\commands\run_cmd.py", line 820, in checkDestinations
    ok = checkStationSuitability(cmdenv, calc, station, '--to')
  File "G:\Elite\Trade-Dangerous\tradedangerous\commands\run_cmd.py", line 626, in checkStationSuitability
    TradeDB.padSizesExt[station.maxPadSize],
NameError: name 'TradeDB' is not defined
```
