### PR TITLE
fix: trade_cmd --reverse flag is supposed to be -r not -R

### DIFF
--- a/tradedangerous/commands/trade_cmd.py
+++ b/tradedangerous/commands/trade_cmd.py
@@ -70,7 +70,7 @@ switches = [
         type = int,
         default = 1,
     ),
-    ParseArgument('--reverse', '-R',
+    ParseArgument('--reverse', '-r',
         help = "Show the reverse trade: swaps origin and dest. This is a convenience for command-line golfers.",
         action = 'store_true',
     ),


### PR DESCRIPTION
I'd not spotted this because supply and demand are *supposed* to be -S and -D to avoid conflict with other -s and -d elsewhere.
