### PR TITLE
fix: guidance when modules missing

### DIFF
--- a/trade.py
+++ b/trade.py
@@ -33,16 +33,57 @@
 # DEVELOPERS: If you are a programmer who wants TD to do something
 # cool, please see the TradeDB and TradeCalc modules. TD is designed
 # to empower other programmers to do cool stuff.
+import os
 import sys
 
-from tradedangerous import cli, SimpleAbort
-
-
-def main(argv = None):
-    cli.main(argv or sys.argv)
+from tradedangerous.version import __version__ as TDVER
 
 
 if __name__ == "__main__":
+    # Import errors could put users outside their comfort zone; be supportive.
+    try:
+        # For testing
+        if os.environ.get("TD_FAIL_IMPORT"):
+            import tradedangerous.yaboono  # noqa   # pylint:disable=unused-import
+
+        from tradedangerous import cli, SimpleAbort
+
+    except ImportError as e:
+        sys.stderr.write(f"** {e.__class__.__name__}: {e}\n")
+        if sys.stderr.isatty():
+            sys.stderr.write("\x1b[1m")  # bold mode
+        sys.stderr.write(
+            "## You may need to install/update one or more dependency: ##\n"
+            "\n"
+            "    pip install --upgrade --user -r requirements.txt\n\n"
+        )
+
+        # if the variable 'VIRTUAL_ENV' is set, --user would break.
+        env = getattr(os, "environ", [])
+        if "VIRTUAL_ENV" in env:
+            sys.stderr.write("or\n\n    pip install --upgrade -r requirements.txt\n\n")
+        if "CONDA_EXE" in env:
+            sys.stderr.write("or\n\n    conda install --yes --file requirements.txt\n\n")
+        if "MAMBA_EXE" in env:
+            sys.stderr.write("or\n\n    mamba install --yes --file requirements.txt\n\n")
+
+        if sys.stderr.isatty():
+            sys.stderr.write("\x1b[0m")  # unbold mode
+        sys.stderr.write("(* exact command may vary if using package managers)\n")
+        sys.stderr.write(f"-- TradeDangerous v{TDVER}\n")
+
+        if 'EXCEPTIONS' in os.environ:
+            raise e  # raise it as it was
+
+        sys.exit(1)
+
+
+    # Back to business
+
+    
+    def main(argv = None):
+        cli.main(argv or sys.argv)
+
     try:
         cli.main(sys.argv)
     except SimpleAbort as e:


### PR DESCRIPTION
Since we're taking users out of their comfort zone, try to be helpful if we're exposing them to dependency-related issues.

Sanity checks:

# Deliberate fail, expose exceptions
<img width="926" height="521" alt="image" src="https://github.com/user-attachments/assets/dd626d87-d503-4133-8c7c-bd7468e64f40" />

# Deliberate fail, no exception exposure
<img width="662" height="251" alt="image" src="https://github.com/user-attachments/assets/9fd401ca-d518-4275-934b-a93151c60133" />

no ansi when piped etc:
<img width="717" height="255" alt="image" src="https://github.com/user-attachments/assets/fc31f30c-e8cc-4fb5-a01b-54b73a8e5571" />

works when not intentionally failing:
<img width="816" height="184" alt="image" src="https://github.com/user-attachments/assets/9444c5d7-fd41-4c52-8ee9-d29af21fa09d" />
