### PR TITLE
fix: add missing orjson dependency in distribution

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
     "rich==13.7.1",
     "importlib-metadata>=1",
     "sqlalchemy>=2.0,<3.0",
+    "orjson>=3.11.5",
     ],
     setup_requires=["pytest-runner"],
     tests_require=["pytest"],


### PR DESCRIPTION
the dependency on orjson was left out of the pypi distribution configuration.