### PR TITLE
refactor: add type hint base to CSVDialect

### DIFF
--- a/tradedangerous/misc/csvdialect.py
+++ b/tradedangerous/misc/csvdialect.py
@@ -1,7 +1,7 @@
 import csv
 
 
-class CSVDialect:
+class CSVDialect(csv.Dialect):
     """
     Defines the TDCSVDialect class for fine-tuning CSV parsing.
     


### PR DESCRIPTION
No functional change, just makes python 3.12+ linters happier.