### PR TITLE
Feat/orm search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,4 +50,5 @@ tools/*
 repo_files.txt
 tradedangerous/db/config.ini
 tmp/
+# Allow notebook experiments in the root to be local.
 /*.ipynb

--- a/tox.ini
+++ b/tox.ini
@@ -180,6 +180,7 @@ commands =
 		tradedangerous/transfers.py \
 		tradedangerous/utils.py \
 		tradedangerous/version.py \
+		tradedangerous/db/search.py \
 		tradedangerous/misc/progress.py \
 		tradedangerous/plugins/eddblink_plug.py \
 		tradedangerous/plugins/spansh_plug.py \

--- a/tradedangerous/db/orm_models.py
+++ b/tradedangerous/db/orm_models.py
@@ -25,6 +25,9 @@ from sqlalchemy.ext.compiler import compiles
 from sqlalchemy.types import TypeDecorator
 
 
+NAME_LENGTH = 40  # Standard maximum length allowed for names by Elite.
+
+
 # ---- Dialect-aware time utilities (moved before model usage) ----
 class now6(expression.FunctionElement):
     """CURRENT_TIMESTAMP with microseconds on MySQL/MariaDB; plain CURRENT_TIMESTAMP elsewhere."""

--- a/tradedangerous/db/search.py
+++ b/tradedangerous/db/search.py
@@ -1,0 +1,367 @@
+"""
+search provides general methods for searching orm tables by name. These
+are primarily provided as back-ends for TradeORM "lookup" methods.
+
+
+# Previously:
+
+The TradeDB lookup methods do some complex, crazy, fuzzy matching taking
+word boundaries and punctuation etc into account.
+
+We have no metrics on how widely used those are, but they would let
+you search for SOL/Abraham Lincoln station with the input "hamlinc".
+
+To do that we loaded all the instances so we could access their names.
+
+TradeDB lookup methods are slow.
+
+
+# New Approach:
+
+Assume and reward users providing copy/pasted names (or passed via
+variables, etc), by hot-pathing exact matches via the database with
+no pre-load required.
+
+Follow with near-match based on prefix, before falling back to highly
+expensive fuzzy matching.
+
+Fuzzy match is still slow because it has to bring every name into
+Python to do the comparison, but it can still be faster than the
+TradeDB approach because it uses like patterns to reduce the sheer
+number of names retrieved.
+
+That is:
+
+   hamlinc -> %h%a%m%l%i%n%c%
+
+While this is an expensive query, it is less expensive than having
+SqlAlchemy surface every station name for python to perform a similar
+filter.
+
+With the Python filter applied to significantly less rows, there is
+still a chance of performance gain.
+"""
+# pylint: disable=deprecated-typing-alias
+from __future__ import annotations
+
+from typing import NamedTuple, Type, TypeVar
+import re
+import typing
+
+from sqlalchemy import Select, Result, select, and_, literal_column
+
+from tradedangerous.tradeexcept import AmbiguityError
+
+from .engine import Session
+from .orm_models import NAME_LENGTH  # pylint: disable=unused-import  # noqa
+from .orm_models import Category, Item, Station, System
+
+
+if typing.TYPE_CHECKING:
+    from typing import Any
+
+# 'T' is used for the find methods as a generic "this table" parameter,
+# 'G' is used for the find methods as a generic "group/parent table" parameter,
+T = TypeVar("T", Category, Item, Station, System)
+G = TypeVar("G", Category, System)
+
+
+class Needle(NamedTuple):
+    """Needle stores a search term decomposed into a normalized
+    form (with spaces and punctuation removed) and a search
+    pattern form (regex/like/etc)."""
+
+    normalized: str         # the collapsed representation
+    pattern: str            # a pattern to search for this sequence of individual characters
+    left_anchored: bool
+    right_anchored: bool
+
+
+# Punctuation (non-whitespace) characters we will discard in normalization.
+NORMALIZE_PUNCT = """/.,;:'"?!+-"""  # '-' must come last to be regex usable
+
+# PUNCT_REGEX is a compiled store of a regex that strips consecutive space/punctation
+# from a term to collapse it to alphanumeric-etc characters. Not ALL punctuation is removed.
+PUNCT_REGEX = re.compile(r"[\s" + NORMALIZE_PUNCT + "]+")
+
+# The 'sub' method of a compiled regex that escapes slash, percent, and understore
+# to make a pattern safe for use in a like query.
+LIKE_ESCAPING = re.compile(r"([\\%_])").sub
+
+
+def escaped_for_like(term: str) -> str:
+    """escaped_for_like returns term with any SQL 'LIKE' characters escaped."""
+    return LIKE_ESCAPING(r"\\\1", term)
+
+
+# python 3.12:
+#  def name_startswith[T](table: T, pattern: str) -> Any:
+def name_startswith(table: Type[T], pattern: str) -> Any:  # todo: correct type
+    """escapes pattern for use in and returns a LIKE expression that matches
+       table.name against pattern%.
+    """
+    return table.name.like(escaped_for_like(pattern) + "%", escape="\\")
+
+
+def needle_from_term(key: str, *, key_prefix: str = "@", key_suffix: str = "/", pattern_prefix: str = "", pattern_suffix: str = "", pattern_wildcard: str = "%") -> Needle:
+    """needle_from_term will produce a Needle instance for the given term, containing
+    the normalized form and the search pattern based on the pattern's wildcard.
+
+    key_prefix and key_suffix specify sequences that can be used to anchor the
+    key to the beginning or end of the search.
+
+    pattern_prefix and pattern_suffix specify sequences that should be injected
+    to the search pattern to anchor it, if required. e.g. '^' and '$' if you want a regex.
+
+    pattern_wildcard is the sequence the matcher needs to express "match 0+ something".
+    """
+    term, left_anchor, right_anchor = key, False, False
+
+    # e.g. "@SOL" (if key_prefix is '@', the default)
+    if term.startswith(key_prefix):
+        left_anchor, term = True, term[1:]
+
+    # e.g "SOL/" (if key_suffix is '/', the default); but only if that's the sole /
+    # "bre\/\/" does not get this treatment
+    if term.find(key_suffix) == len(term) - 1:
+        right_anchor, term = True, term[:-1]
+
+    if len(term) == 0:
+        raise ValueError("empty field")
+    # Enforce maximum search length per API contract
+    if len(term) > NAME_LENGTH:
+        raise ValueError(f"names are limited to {NAME_LENGTH} characters, got {len(term)}: {term[:NAME_LENGTH]}...")
+    # this may be an overly aggressive constraint, but I'm trying to avoid wasting
+    # the user's time with "'a' could match ..." or "' ' could match ...".
+    if len(term) == 1:
+        raise ValueError(f"overly ambiguous field: '{key}'")
+
+    # split into characters which we then paper-doll with wildcards,
+    # so that 'g m t a' can match 'gotta match them all' via '%g%m%t%a%'
+    components = PUNCT_REGEX.split(term.lower())
+    normalized = "".join(components)
+    characters = list(normalized)
+    # Escape each character individually so wildcards don't break escape sequences
+    escaped_chars = [escaped_for_like(c) for c in characters]
+    # @SOL is left-anchored, so it doesn't start with a wildcard.
+    prefix = pattern_prefix if left_anchor else pattern_wildcard
+    # SOL/ is right-anchored so it doesn't end with a wildcard.
+    suffix = pattern_suffix if right_anchor else pattern_wildcard
+
+    pattern = f"{prefix}{pattern_wildcard.join(escaped_chars)}{suffix}"
+
+    return Needle(normalized, pattern, left_anchor, right_anchor)
+
+
+# python 3.12:
+#   def fuzzy_like[T, G](tdo: TradeORM, kind: str, term: str, table: T, parent: G | None = None) -> T:
+def fuzzy_like(session: Session, kind: str, term: str, table: Type[T], group_table: Type[G] | None = None) -> T | None:
+    """fuzzy_like attempts to find the a best match given a search key by finding
+    all potential matches and then testing them for similarity/ambiguity.
+    :param session: the database session to use for the query
+    :param kind: textual label for the query (for error messages)
+    :param term: the search term (name)
+    :param table: the *Type* of the table to search, e.g. orm_models.Station
+    :param group_table: optional *Type* of the parent/group table, e.g. orm_models.System
+    :returns: the best-matching instance, or None if no matches found
+    :raises AmbiguityError: if multiple matches are found that cannot be disambiguated
+    """
+    needle = needle_from_term(term)
+
+    # when there's no category, it's a one-table query
+    # if there's a parent we need to join it and concat the names (parent/table)
+    if not group_table:
+        query_field = table.name.label("match_name")
+        query_from = select(table, query_field)
+    else:
+        # Use || operator which works on both SQLite and MariaDB for string concatenation
+        query_field = (group_table.name + literal_column("'/'") + table.name).label("match_name")
+        query_from = select(table, query_field).join(group_table)
+
+    stmt = query_from.where(query_field.like(needle.pattern))
+    rows: Result[Any] = session.execute(stmt)
+
+    # 1: exact, 2: prefix-partial, 3: contains (as-is), 4: fuzzy
+    matches: dict[int, list[T]] = {1: [], 2: [], 3: [], 4: []}
+
+    for row in rows:
+        match_name = row[1].lower()
+        match_norm = PUNCT_REGEX.sub("", match_name)  # normalized
+        if needle.normalized in match_norm:
+            if needle.normalized == match_norm:
+                score = 1  # exact match
+            elif match_norm.startswith(needle.normalized):
+                score = 2  # prefix partial
+            else:
+                score = 3  # contains as-is
+        else:
+            # fuzziest match (all characters occur in that order but not contiguous)
+            # 'solr' <-willmatch- 's ol 4.1 ar'
+            score = 4
+        matches[score].append(row[0])
+
+    # The match is considered unambiguous if we can find a bucket with a single
+    # match before we find a bucket with > 1 match.
+    for bucket in (1, 2, 3, 4):
+        matched = matches[bucket]
+        match len(matched):
+            case 0:
+                continue  # nothing in this bucket
+            case 1:
+                return matched[0]  # single item
+            case _:
+                raise AmbiguityError(kind, term, matched, key=lambda i: i.dbname())
+
+    return None
+
+
+# python 3.12:
+#  def fast_find[T](tdo: TradeORM, kind: str, key: str, table: T) -> T | None:
+def fast_find(session: Session, kind: str, key: str, table: Type[T]) -> T | None:
+    """ search a single table for a term and find a unique match based on either
+        exact-match or unique prefix match.
+
+        :param session: the database session to use for the query
+        :param kind: textual label for the query (for error messages)
+        :param key: the search term (name)
+        :param table: the *Type* of the table to search, e.g. orm_models.Station
+        :returns: the best-matching instance, or None if no matches found
+        :raises AmbiguityError: if multiple matches are found that cannot be disambiguated
+    """
+    if len(key) < 2:
+        raise ValueError(f"overly ambiguous {kind} key: {key}")
+
+    # exact matching
+    stmt = select(table).where(table.name == key)
+    rows = session.execute(stmt.limit(10)).all()
+    if len(rows) == 1:
+        return rows[0][0]
+    if len(rows) > 1:
+        models = [row[0] for row in rows]
+        raise AmbiguityError(kind, key, models, key=lambda i: i.dbname())
+
+    # prefix matching
+    stmt = select(table).where(name_startswith(table, key))
+    rows = session.execute(stmt.limit(10)).all()
+    if len(rows) == 1:
+        return rows[0][0]
+    if len(rows) > 1:
+        models = [row[0] for row in rows]
+        raise AmbiguityError(kind, key, models, key=lambda i: i.dbname())
+    return None
+
+
+# python 3.12:
+#  def fast_find_sub[T, G](tdo: TradeORM, key: str, table: T, group_table: G) -> T | G | None:
+def fast_find_sub(session: Session, kind: str, key: str, table: Type[T], group_table: Type[G]) -> T | G | None:
+    """ fast_find_sub attempts to find either a group (parent) or child item
+        based on the given key. The key may express parent/child relationships
+        using the '@' and '/' prefix/separator notations.
+
+        :param session: the database session to use for the query
+        :param kind: textual label for the query (for error messages)
+        :param key: the search term (name)
+        :param table: the *Type* of the child table to search, e.g. orm_models.Station
+        :param group_table: the *Type* of the parent/group table, e.g. orm_models.System
+        :returns: the best-matching table or group_table instance, or None if no matches found
+        :raises AmbiguityError: if multiple matches are found that cannot be disambiguated
+    """
+    if len(key) < 2:
+        raise ValueError(f"overly ambiguous search key: {key}")
+
+    # Start with a list of most-likely simple, exact (fast) matches that most paths
+    # will most likely want.
+    exact_candidates: list[Select[Any]] = [
+        select(table).where(table.name == key),
+        select(group_table).where(group_table.name == key),
+    ]
+    # Those will be followed by slower, like-based matches - this relies
+    # on our tables having no-case collation to avoid manipulating text case.
+    like_candidates: list[Select[Any]] = [
+        select(table).where(name_startswith(table, key)),
+        select(group_table).where(name_startswith(group_table, key)),
+    ]
+
+    prefix_anchored = key.startswith("@")
+    slash = key.find("/")
+
+    # Possible combinations:
+    #   @/abc  explicit non-expression of parent, anchored child; child = abc%
+    #   @abc/  explicit expression of exact parent (trailing slash) parent = abc
+    #   @abc   explicit expression of only the parent (no slash). parent = abc%
+    #   @ab/cd explicit parent + child. parent = ab, child = cd
+    #   abc/   explicit parent; parent = abc%
+    #   /abc   explicit child; child = %abc%
+    #   ab/cd  child + parent
+
+    if prefix_anchored:  # "@parent", "@par/", "@/child", ...
+        if slash == 1:  # "@", "/", ... -> left-anchored child
+            if len(key) == 2:  # reject "@/"
+                raise ValueError(f"overly ambiguous term (no actual characters): {key}")
+            # search for just the child part
+            exact_candidates.insert(0, select(table).where(table.name == key[2:]))
+            like_candidates.insert(0, select(table).where(name_startswith(table, key[2:])))
+
+        elif slash == -1:  # @abc... no slash, just the parent
+            exact_candidates.insert(0, select(group_table).where(group_table.name == key[1:]))
+            like_candidates.insert(0, select(group_table).where(name_startswith(group_table, key[1:])))
+        else:  # @sol/[something...] <- combo
+            parent_part, child_part = key[1:slash], key[slash + 1:]
+            if not child_part:  # @sol/
+                exact_candidates = [select(group_table).where(group_table.name == parent_part)]
+                like_candidates = []
+            else:
+                exact_candidates.append(select(table).join(group_table).where(and_(group_table.name == parent_part, table.name == child_part)))
+                like_candidates.insert(0, select(table).join(group_table).where(and_(name_startswith(group_table, parent_part), name_startswith(table, child_part))))
+                like_candidates.insert(0, select(table).join(group_table).where(and_(group_table.name == parent_part, name_startswith(table, child_part))))
+
+    # otherwise if the parent isn't anchored, it can be a wildcard.
+    elif slash == len(key) - 1:  # "foo/"
+        parent_part = key[:-1]
+        # This tells us there's a single slash and it's at the end of the name,
+        # in which case we're going to treat it *first* as a group name.
+        # We still fall back to trying it directly but only as a last resort;
+        # there *are* player-named places with a '/' at the end ("Here No\/\/")
+        # but let that query pay for itself, not the other way around.
+        exact_candidates = [
+            select(group_table).where(group_table.name == key),
+            select(group_table).where(group_table.name == parent_part),
+            select(table).where(table.name == key),
+        ]
+        like_candidates = [
+            select(group_table).where(name_startswith(group_table, key)),
+            select(group_table).where(name_startswith(group_table, parent_part)),
+            select(table).where(name_startswith(table, parent_part)),
+        ]
+
+    elif slash > 0:  # "par/table", and we know it's not trailing /
+        parent_part, _, child_part = key.partition("/")
+
+        exact_candidates = [
+            select(table).where(table.name == key),
+            # don't try matching the group because no groups can currently contain '/'.
+            select(table).join(group_table).where(and_(group_table.name == parent_part, table.name == child_part)),
+        ]
+        like_candidates = [
+            select(table).where(name_startswith(table, key)),
+            select(table).join(group_table).where(group_table.name == parent_part, name_startswith(table, child_part)),
+            select(table).join(group_table).where(name_startswith(group_table, parent_part), table.name == child_part),
+            select(table).join(group_table).where(name_startswith(group_table, parent_part), name_startswith(table, child_part)),
+        ]
+
+    elif slash <= 0:  # "/foo" or "foo" suggests only a child
+        child_part = key[1:] if slash == 0 else key
+        exact_candidates.insert(0, select(table).where(table.name == child_part))
+        like_candidates.insert(0, select(table).where(name_startswith(table, child_part)))
+
+    # If there's no slash, then our initial patterns will suffice.
+
+    for stmt in exact_candidates + like_candidates:
+        rows = session.execute(stmt.limit(10)).all()
+        if len(rows) == 1:
+            return rows[0][0]
+        if len(rows) > 1:  # ambiguity/conflict
+            models = [row[0] for row in rows]
+            raise AmbiguityError(kind, key, models, key=lambda r: r.dbname())
+
+    return None

--- a/tradedangerous/db/test_search.py
+++ b/tradedangerous/db/test_search.py
@@ -1,0 +1,361 @@
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, Session
+
+from tradedangerous.db import search
+from tradedangerous.db.orm_models import Base, Category, Item
+from tradedangerous.tradeexcept import AmbiguityError
+
+
+# -----------------------------------------------------------------------------
+# Test Data
+
+# Mock category data: (category_id, name)
+MOCK_CATEGORIES = [
+    (1, "Metals"),
+    (2, "Minerals"),
+    (3, "Chemicals"),
+    (4, "Foods"),
+    (5, "Misc"),
+]
+
+# Mock item data: (item_id, name, category_id, ui_order, avg_price, fdev_id)
+MOCK_ITEMS = [
+    (100, "Platinum", 1, 0, 0, 100),
+    (101, "Gold", 1, 0, 0, 101),
+    (102, "Gold Pressed Latinum", 1, 0, 0, 102),
+    (103, "Bertrandite", 2, 0, 0, 103),
+    (104, "Fruit and Vegetables", 4, 0, 0, 104),
+    (105, "Food Cartridges", 4, 0, 0, 105),
+    (106, "Non-Lethal Weapons", 5, 0, 0, 106),
+    (107, "H.E. Suits", 5, 0, 0, 107),
+    (108, "Agri-Medicines", 5, 0, 0, 108),
+    (109, "Baltah'sine Vacuum Krill", 5, 0, 0, 109),
+]
+
+
+@pytest.fixture
+def test_session() -> Session:
+    """Create an in-memory SQLite session with test Category and Item data.
+    
+    Uses MOCK_CATEGORIES and MOCK_ITEMS constants to populate the database.
+    """
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    
+    SessionLocal = sessionmaker(bind=engine)
+    session = SessionLocal()
+    
+    # Populate from MOCK_CATEGORIES
+    for cat_id, name in MOCK_CATEGORIES:
+        session.add(Category(category_id=cat_id, name=name))
+    session.flush()
+    
+    # Populate from MOCK_ITEMS
+    for item_id, name, category_id, ui_order, avg_price, fdev_id in MOCK_ITEMS:
+        session.add(Item(
+            item_id=item_id,
+            name=name,
+            category_id=category_id,
+            ui_order=ui_order,
+            avg_price=avg_price,
+            fdev_id=fdev_id
+        ))
+    session.commit()
+    
+    yield session
+    session.close()
+
+
+# -----------------------------------------------------------------------------
+# PUNCT_REGEX test
+
+def test_PUNCT_REGEX() -> None:
+    """Test that PUNCT_REGEX correctly strips punctuation and whitespace."""
+    assert search.PUNCT_REGEX.sub("", "") == ""
+    assert search.PUNCT_REGEX.sub("", "normalstring") == "normalstring"
+    assert search.PUNCT_REGEX.sub("", """/.,;:'"?!++-""") == ""
+    assert search.PUNCT_REGEX.sub("", "Hello, world!") == "Helloworld"
+
+
+# -----------------------------------------------------------------------------
+# escaped_for_like validation
+
+@pytest.mark.parametrize("input_str,expected", [
+    ("", ""),
+    ("normalstring", "normalstring"),
+    ("abc 123 ~`!@#$^&*()-+=[]{};:/", "abc 123 ~`!@#$^&*()-+=[]{};:/"),
+])
+def test_escaped_for_like_normal_chars(input_str: str, expected: str) -> None:
+    """Test that non-special characters pass through unchanged."""
+    assert search.escaped_for_like(input_str) == expected
+
+
+@pytest.mark.parametrize("input_str,expected", [
+    ("%", r"\%"),
+    ("_", r"\_"),
+    ("\\", "\\\\"),
+    ("50%", "50\\%"),
+    ("test_item", "test\\_item"),
+    ("path\\to\\file", "path\\\\to\\\\file"),
+    (r"\\\%\_\ ", r"\\\\\\\%\\\_\\ "),
+])
+def test_escaped_for_like_special_chars(input_str: str, expected: str) -> None:
+    """Test that SQL LIKE special characters ('%', '_', '\\') are properly escaped."""
+    assert search.escaped_for_like(input_str) == expected
+
+
+# -----------------------------------------------------------------------------
+# needle_from_term tests
+
+@pytest.mark.parametrize("bad_value", [
+    "",
+    "@",
+    "/",
+    "@/",
+])
+def test_needle_from_term_empty_raises(bad_value: str) -> None:
+    """Test that empty search terms raise appropriate ValueError."""
+    with pytest.raises(ValueError) as excinfo:
+        search.needle_from_term(bad_value)
+    assert str(excinfo.value) == "empty field"
+
+
+@pytest.mark.parametrize("bad_value", ["@a", "a/", "@a/"])
+def test_needle_from_term_single_char_raises(bad_value: str) -> None:
+    """Test that single-character searches raise 'overly ambiguous' ValueError."""
+    with pytest.raises(ValueError) as excinfo:
+        search.needle_from_term(bad_value)
+    assert str(excinfo.value) == f"overly ambiguous field: '{bad_value}'"
+
+
+def test_needle_from_term_too_long_raises() -> None:
+    """Test that terms exceeding NAME_LENGTH raise ValueError."""
+    long_term = "a" * (search.NAME_LENGTH + 1)
+    with pytest.raises(ValueError) as excinfo:
+        search.needle_from_term(long_term)
+    assert f"limited to {search.NAME_LENGTH}" in str(excinfo.value).lower()
+    assert str(search.NAME_LENGTH) in str(excinfo.value)
+
+
+def test_needle_from_term_escapes_special_chars() -> None:
+    """Test that needle patterns escape SQL special chars before building pattern."""
+    needle = search.needle_from_term("abc")
+    assert needle.pattern == "%a%b%c%"
+
+    needle = search.needle_from_term("%\\_")
+    assert needle.pattern == "%\\%%\\\\%\\_%"
+
+
+@pytest.mark.parametrize("term,normalized,pattern,left_anchor,right_anchor", [
+    ("SOL", "sol", "%s%o%l%", False, False),
+    ("@sOl", "sol", "s%o%l%", True, False),
+    ("sOl/", "sol", "%s%o%l", False, True),
+    ("@sOl/", "sol", "s%o%l", True, True),
+    ("G-M:T,A", "gmta", "%g%m%t%a%", False, False),
+])
+def test_needle_from_term_valid(
+    term: str,
+    normalized: str,
+    pattern: str,
+    left_anchor: bool,
+    right_anchor: bool
+) -> None:
+    """Test valid needle_from_term cases with various anchor combinations."""
+    n = search.needle_from_term(term)
+    assert n.normalized == normalized
+    assert n.pattern == pattern
+    assert n.left_anchored == left_anchor
+    assert n.right_anchored == right_anchor
+
+
+def test_needle_from_term_max_length_boundary() -> None:
+    """Verify MAX_NAME_LENGTH boundary behavior (39, 40, 41 characters)."""
+    # One below limit should work
+    term_39 = "a" * (search.NAME_LENGTH - 1)
+    n = search.needle_from_term(term_39)
+    assert n.normalized == term_39.lower()
+    
+    # Exactly at limit should work
+    term_40 = "a" * search.NAME_LENGTH
+    n = search.needle_from_term(term_40)
+    assert n.normalized == term_40.lower()
+    
+    # One above limit should fail
+    term_41 = "a" * (search.NAME_LENGTH + 1)
+    with pytest.raises(ValueError) as excinfo:
+        search.needle_from_term(term_41)
+    assert f"limited to {search.NAME_LENGTH}" in str(excinfo.value).lower()
+
+
+# -----------------------------------------------------------------------------
+# fuzzy_like tests
+
+class TestFuzzyLike:
+    """Test the fuzzy_like function with multi-tier matching."""
+    
+    def test_exact_match(self, test_session: Session) -> None:
+        """Exact match should return the single item (bucket 1 priority)."""
+        result = search.fuzzy_like(test_session, "Item", "Platinum", Item)
+        assert result is not None
+        assert result.item_id == 100
+        assert result.name == "Platinum"
+    
+    def test_prefix_match(self, test_session: Session) -> None:
+        """Prefix match should find unique item starting with prefix (bucket 2)."""
+        result = search.fuzzy_like(test_session, "Item", "Plat", Item)
+        assert result is not None
+        assert result.item_id == 100
+        assert result.name == "Platinum"
+    
+    def test_contains_match(self, test_session: Session) -> None:
+        """Contains match should find item with characters in sequence (bucket 3)."""
+        result = search.fuzzy_like(test_session, "Item", "gold p", Item)
+        assert result is not None
+        assert result.item_id == 102
+        assert result.name == "Gold Pressed Latinum"
+    
+    def test_fuzzy_match_punctuation_normalized(self, test_session: Session) -> None:
+        """Punctuation should be stripped during fuzzy matching (bucket 4)."""
+        # Search for "baltah sine" should match "Baltah'sine Vacuum Krill"
+        result = search.fuzzy_like(test_session, "Item", "baltah sine", Item)
+        assert result is not None
+        assert result.item_id == 109
+    
+    @pytest.mark.parametrize("search_term", ["go", "gol"])
+    def test_ambiguous_prefix(self, test_session: Session, search_term: str) -> None:
+        """Multiple prefix matches should raise AmbiguityError."""
+        with pytest.raises(AmbiguityError) as excinfo:
+            search.fuzzy_like(test_session, "Item", search_term, Item)
+        assert search_term in str(excinfo.value).lower()
+    
+    def test_no_match(self, test_session: Session) -> None:
+        """No matching characters should return None."""
+        result = search.fuzzy_like(test_session, "Item", "xyz", Item)
+        assert result is None
+    
+    def test_with_category_parent(self, test_session: Session) -> None:
+        """Fuzzy match with parent category join should work."""
+        result = search.fuzzy_like(test_session, "Item", "plat", Item, Category)
+        assert result is not None
+        assert result.item_id == 100
+        assert result.name == "Platinum"
+    
+    def test_exact_wins_over_prefix(self, test_session: Session) -> None:
+        """Exact matches (bucket 1) should win over prefix matches (bucket 2)."""
+        # "Gold" is exact, so it should win over "Gold Pressed Latinum" prefix
+        result = search.fuzzy_like(test_session, "Item", "gold", Item)
+        assert result is not None
+        assert result.item_id == 101
+        assert result.name == "Gold"
+    
+    def test_prefix_wins_over_contains(self, test_session: Session) -> None:
+        """Prefix matches (bucket 2) should win over contains matches (bucket 3)."""
+        result = search.fuzzy_like(test_session, "Item", "plat", Item)
+        assert result is not None
+        assert result.item_id == 100
+        assert result.name == "Platinum"
+
+
+# -----------------------------------------------------------------------------
+# fast_find tests
+
+class TestFastFind:
+    """Test the fast_find function for single-table searches."""
+    
+    def test_exact_match(self, test_session: Session) -> None:
+        """Exact match should return the item."""
+        result = search.fast_find(test_session, "Item", "Platinum", Item)
+        assert result is not None
+        assert result.item_id == 100
+    
+    def test_prefix_match(self, test_session: Session) -> None:
+        """Unique prefix match should return the item."""
+        result = search.fast_find(test_session, "Item", "Plat", Item)
+        assert result is not None
+        assert result.item_id == 100
+    
+    def test_ambiguous_prefix(self, test_session: Session) -> None:
+        """Multiple prefix matches should raise AmbiguityError."""
+        with pytest.raises(AmbiguityError) as excinfo:
+            search.fast_find(test_session, "Item", "Go", Item)
+        assert "Go" in str(excinfo.value)
+    
+    def test_no_match(self, test_session: Session) -> None:
+        """No matching item should return None."""
+        result = search.fast_find(test_session, "Item", "Nonexistent", Item)
+        assert result is None
+    
+    def test_short_key_raises(self, test_session: Session) -> None:
+        """Key shorter than 2 characters should raise ValueError."""
+        with pytest.raises(ValueError) as excinfo:
+            search.fast_find(test_session, "Item", "P", Item)
+        assert "overly ambiguous" in str(excinfo.value)
+
+
+# -----------------------------------------------------------------------------
+# fast_find_sub tests
+
+class TestFastFindSub:
+    """Test the fast_find_sub function for parent/child hierarchical searches."""
+    
+    def test_exact_child_match(self, test_session: Session) -> None:
+        """Exact child match should return the item."""
+        result = search.fast_find_sub(test_session, "Item", "Platinum", Item, Category)
+        assert result is not None
+        assert result.item_id == 100
+    
+    def test_exact_parent_match(self, test_session: Session) -> None:
+        """Exact parent match should return the category."""
+        result = search.fast_find_sub(test_session, "Category", "Metals", Item, Category)
+        assert result is not None
+        assert result.category_id == 1
+    
+    def test_parent_slash_child(self, test_session: Session) -> None:
+        """Format 'Parent/Child' should find the child item."""
+        result = search.fast_find_sub(test_session, "Item", "Metals/Gold", Item, Category)
+        assert result is not None
+        assert result.item_id == 101
+        assert result.name == "Gold"
+    
+    def test_parent_trailing_slash(self, test_session: Session) -> None:
+        """Trailing slash format 'Parent/' should find the parent category."""
+        result = search.fast_find_sub(test_session, "Category", "Metals/", Item, Category)
+        assert result is not None
+        assert result.category_id == 1
+    
+    def test_anchor_parent_only(self, test_session: Session) -> None:
+        """Anchor '@Parent' should find the parent category."""
+        result = search.fast_find_sub(test_session, "Category", "@Metals", Item, Category)
+        assert result is not None
+        assert result.category_id == 1
+    
+    def test_anchor_child_only(self, test_session: Session) -> None:
+        """Anchor '@/Child' should find the child item."""
+        result = search.fast_find_sub(test_session, "Item", "@/Platinum", Item, Category)
+        assert result is not None
+        assert result.item_id == 100
+    
+    def test_anchor_parent_child(self, test_session: Session) -> None:
+        """Anchor '@Parent/Child' should find the child item."""
+        result = search.fast_find_sub(test_session, "Item", "@Metals/Gold", Item, Category)
+        assert result is not None
+        assert result.item_id == 101
+    
+    def test_leading_slash_child_search(self, test_session: Session) -> None:
+        """Leading slash '/Child' should search only children."""
+        result = search.fast_find_sub(test_session, "Item", "/Platinum", Item, Category)
+        assert result is not None
+        assert result.item_id == 100
+    
+    def test_short_key_raises(self, test_session: Session) -> None:
+        """Key shorter than 2 characters should raise ValueError."""
+        with pytest.raises(ValueError) as excinfo:
+            search.fast_find_sub(test_session, "Item", "A", Item, Category)
+        assert "overly ambiguous" in str(excinfo.value)
+    
+    def test_empty_anchor_raises(self, test_session: Session) -> None:
+        """Empty anchor format '@/' should raise ValueError."""
+        with pytest.raises(ValueError) as excinfo:
+            search.fast_find_sub(test_session, "Item", "@/", Item, Category)
+        assert "no actual characters" in str(excinfo.value)

--- a/tradedangerous/tradeorm.py
+++ b/tradedangerous/tradeorm.py
@@ -22,6 +22,7 @@ from .db import (
     orm_models as orm,          # type: ignore  # so we can access models easily
     make_engine_from_config,    # type: ignore
     get_session_factory,        # type: ignore
+    search as db_search,
 )
 
 if typing.TYPE_CHECKING:
@@ -88,16 +89,20 @@ class TradeORM:
             'system name/station name' component. If the station does not
             match a unique station, raises an AmbiguityError
         """
-        if "%" in name:
-            raise TradeException("wildcards ('%') are not supported in station names")
-        if "/" not in name:
-            if (station := self._station_lookup(name, exact=True, partial=False)):
-                return station
-            if self._system_lookup(name, exact=True, partial=False):
-                raise SystemNotStationError(f'"{name}" is a system name, use "/{name}" if you meant it as a station')
-            name = "/" + name
-        station: orm.Station | None = self.lookup_place(name)
-        return station
+        if (fast_candidate := db_search.fast_find_sub(self.session, "Station", name, orm.Station, orm.System)):
+            if isinstance(fast_candidate, orm.Station):
+                return fast_candidate
+            if isinstance(fast_candidate, orm.System) and fast_candidate.name.lower() == name.lower():
+                raise TradeException(
+                    f"expected a station, '{name}' is a system."
+                    f" you can use '/{name}' to ignore the system match."
+                )
+
+        fuzzy_candidate = db_search.fuzzy_like(self.session, "Station", name, table=orm.Station, group_table=orm.System)
+        if isinstance(fuzzy_candidate, orm.Station):
+            return fuzzy_candidate
+
+        return None
     
     def lookup_system(self, name: str) -> orm.System | None:
         """ Use the database to lookup a system, which accepts a name that
@@ -105,86 +110,13 @@ class TradeORM:
             'system name/station name' component. If the system does not
             match a unique system, raises an AmbiguityError
         """
-        if "%" in name:
-            raise TradeException("wildcards ('%') are not supported in system names")
-        system_name, _, _ = name.partition("/")
-        if not system_name:
-            raise TradeException(f"system name required for system lookup, got {name}")
-        result: orm.Station | orm.System | None = self.lookup_place(system_name)
-        if isinstance(result, orm.Station):
-            return result.system
-        return result
+        if (system := db_search.fast_find(self.session, "System", name, table=orm.System)):
+            return system
+        return db_search.fuzzy_like(self.session, "System", name, table=orm.System, group_table=None)
     
     def lookup_place(self, name: str) -> orm.Station | orm.System | None:
         """ Using a "[<system>]/[<station>]" style name, look up either a Station or a System."""
-        if "%" in name:
-            raise TradeException("wildcards ('%') are not supported in names")
-        sys_name, slashed, stn_name = name.partition("/")
-        if not slashed:
-            if stn_name:
-                station: orm.Station | None = self._station_lookup(stn_name, exact=True, partial=False)
-                if station:
-                    return station
-            if sys_name:
-                system: orm.System | None = self._system_lookup(sys_name, exact=True, partial=False)
-                if system:
-                    return system
-        
-        if sys_name:
-            system = self._system_lookup(sys_name)
-            if not system:
-                raise TradeException(f"unknown system: {sys_name}")
-            if not stn_name:
-                return system
-            
-            # Now we match the list of station names for this system.
-            stmt = self.session.query(orm.Station).filter(orm.Station.system_id == system.system_id).filter(orm.Station.name == stn_name)
-            results = stmt.all()
-            if len(results) == 1:
-                return results[0]
+        if (candidate := db_search.fast_find_sub(self.session, "Place", name, orm.Station, orm.System)):
+            return candidate
 
-            stmt = self.session.query(orm.Station).filter(orm.Station.system_id == system.system_id).filter(orm.Station.name.like(f"%{stn_name}%"))
-            results = stmt.all()
-            if not results:
-                raise TradeException(f"no station in {sys_name} matches '{stn_name}'")
-            if len(results) > 1:
-                raise AmbiguityError("Station", stn_name, [s.name for s in results])
-            return results[0]
-        
-        station = self._station_lookup(stn_name, exact=False)
-        return station
-    
-    def _system_lookup(self, name: str, *, exact: bool = True, partial: bool = True) -> orm.System | None:
-        """ Look up a model by exact name match. """
-        assert exact or partial, "at least one of exact or partial must be True"
-        results: list[orm.System] | None = None
-        if exact:
-            results = self.session.query(orm.System).filter(orm.System.name == name).all()
-            if len(results) == 1:
-                partial = False
-        if partial:
-            like_pattern = f"%{name}%"
-            results = self.session.query(orm.System).filter(orm.System.name.like(like_pattern)).all()
-        
-        if not results:
-            return None
-        if len(results) > 1:
-            raise AmbiguityError("System", name, results, key=lambda s: s.dbname())
-        return results[0]
-    
-    def _station_lookup(self, name: str, *, exact: bool = True, partial: bool = True) -> orm.Station | None:
-        """ Look up a model by exact name match. """
-        assert exact or partial, "at least one of exact or partial must be True"
-        results: list[orm.Station] | None = None
-        if exact:
-            results = self.session.query(orm.Station).filter(orm.Station.name == name).all()
-            if len(results) == 1:
-                partial = False
-        if partial:
-            like_pattern = f"%{name}%"
-            results = self.session.query(orm.Station).filter(orm.Station.name.like(like_pattern)).all()
-        if not results:
-            return None
-        if len(results) > 1:
-            raise AmbiguityError("Station", name, results, key=lambda s: s.dbname())
-        return results[0]
+        return db_search.fuzzy_like(self.session, "Place", name, orm.Station, orm.System)


### PR DESCRIPTION
wip - I still need to round out the tests, but if either of you wants visibility before then.

- I put it in db because that's how I think, what I was avoiding was blowing trade.py away with this specific sub-concern;
- my first next alternative was having "tradeorm" be a directory rather than a single file, so it could be broken up accordingly, but in that case it felt like it should just be called "db" back to square one :)
- why did I think "well this isn't tradeorm"? Just hits me as not actually an ORM specific concern per-se. 