### PR TITLE
chore: add 3.13 and 3.14 to versions we actually test

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -21,7 +21,7 @@ platform =
     linux|linux2|darwin|nt|win32|win64
 # changedir = {toxinidir}/tradedangerous   # ?
 
-[testenv:py{37,38,39,310,311,312}]
+[testenv:py{37,38,39,310,311,312,313,314}]
 deps = -r requirements-dev.txt
 commands =
     coverage run --parallel-mode --source=tradedangerous -m pytest {posargs}


### PR DESCRIPTION
3.13 and 3.14 were not actually running tests or coverage due to not having an env definition