### PR TITLE
Optimize db.utils.parse_ts

### DIFF
--- a/research/perf/bench_parse_ts.py
+++ b/research/perf/bench_parse_ts.py
@@ -1,0 +1,62 @@
+from datetime import datetime, timezone, timedelta
+import math
+import time
+
+import helpers
+
+from tradedangerous.db.utils import parse_ts
+
+cases = [
+    None,
+
+    1,                          
+    86400 * 42 * 365,
+    86400 * 24 * 365 * 3.141,
+] + list(
+ datetime(1970, 1, 1, 1, 0, 0, 0, tzinfo=zone) for zone in [timezone.utc, timezone(timedelta(hours=-1)), timezone(timedelta(hours=2, minutes=30))]
+) + list(
+ datetime(2026, 1, 2, 3, 4, 5, 6, tzinfo=zone) for zone in [timezone.utc, timezone(timedelta(hours=-8)), timezone(timedelta(hours=5))]
+) + [
+  "2020-01-01T00:00:00.000",
+  "2020-01-01T00:00:00+0000",
+  "2020-01-01T00:00:00+00:00",
+  "2020-01-01 00:00:00+00:00",
+  "2020-01-01Z00:00:00",
+]
+
+# Make a lot of cases
+cases = cases * 307
+
+# Do a few thousand repeats of them all
+iterations = 5003
+
+timings = helpers.iterate(parse_ts, cases=cases, iterations=iterations, display=100)
+
+# Timings are in seconds, multiply to milliseconds
+timings[:] = [t*1000 for t in timings]
+
+best, timings, worst = timings[0], timings[1:-1], timings[-1]
+avg = sum(timings) / len(timings)
+
+p10 = helpers.percentile(timings, 10)
+p25 = helpers.percentile(timings, 25)
+p50 = helpers.percentile(timings, 50)
+p90 = helpers.percentile(timings, 90)
+p99 = helpers.percentile(timings, 99)
+
+print(
+  f"ex-best: {best:.3f}ms, "
+  f"best: {timings[0]:.3f}ms, "
+  f"avg: {avg:.3f}ms, "
+  f"worst: {timings[-1]:.3f}ms, "
+  f"ex-worst: {worst:.3f}ms, "
+)
+print(
+  f"p10: {p10:.3f}ms, "
+  f"p25: {p25:.3f}ms, "
+  f"p50: {p50:.3f}ms, "
+  f"p90: {p90:.3f}ms, "
+  f"p99: {p99:.3f}ms, "
+)
+
+  

--- a/research/perf/helpers.py
+++ b/research/perf/helpers.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+from pathlib import Path
+import math
+import time
+import typing
+import sys
+
+ANSI_CURS_UP = "\x1b[1A\x1B[K" if sys.stdout.isatty() else ""
+
+# Make sure that the project root is in the import path
+sys.path.insert(0, str(Path(__file__).parent.parent.parent))
+
+
+def iterate(op: callable, *, cases: typing.Any = None, iterations: int, display: int = 10, label: str = None) -> list[float]:
+    """ makes calls to a particular callable for N iterations and returns the sorted list of timings.
+        prints progress every 'display' iterations, unless display is 0.
+        progress display is prefixed with 'label' or 'Iteration'
+    """
+    label = label or "Iteration"        # What to call ourselves
+    max_iter = f"{iterations:n}"        # So we can size the current iteration similarly
+    timings = []                        # Where we're going to capture the timings
+
+    if ANSI_CURS_UP:
+        print("")  # reserve ourselves a clean line
+
+    run_start = time.time()
+    for i in range(iterations):
+        if display and i % display == 0:
+            now = time.time()
+            print(f"{ANSI_CURS_UP}{label} {i+1:{len(max_iter)}n}/{max_iter} ({now - run_start:.3f}s)")
+
+        iter_start = time.time()
+        if cases:
+            for case in cases:
+                op(case)
+        else:
+            op()
+        timings += [time.time() - iter_start]
+
+    timings.sort()
+
+    print(f"{ANSI_CURS_UP}{label} {max_iter} iters took {sum(timings):.3f}s, bench {time.time() - run_start:.3f}s")
+
+    return timings
+
+
+def percentile(sorted_values: list[float | int] | tuple[float | int], point: float) -> float | int:
+    """ return the Nth percentile value from a sorted list of values.
+        point must be a value between 0-100,
+        sorted_values must be a list or tuple that has been sorted """
+    if point <= 0:
+        if point < 0:
+            raise ValueError("negative percentile index")
+        return values[0]
+    if point >= 100:
+        if point > 100:
+            raise ValueError("percentile > 100 is meaningless")
+        return values[-1]
+
+    # calculate the element index as a float value; e.g. the 50th percentile
+    # of a list containing 2 items is midway between two items - 0th and 1th elements.
+    # the 50th percentile for a list containing 100 items is between the 49th 50th element
+    # the 95th percentile for a list containing 10 items is between 8 and 9, but should
+    # lean closer to the 9th value, so we interpolate
+    fpoint = (point / 100) * (len(sorted_values) - 1)  # think of this as "gap constraining"
+    index = int(fpoint)
+    frac = fpoint - index
+    if math.isclose(frac, 0):
+      return sorted_values[index]
+    # linear interpolated 'average' between the two values
+    return sorted_values[index] * (1 - frac) + sorted_values[index + 1] * frac

--- a/tradedangerous/db/test_utils.py
+++ b/tradedangerous/db/test_utils.py
@@ -1,0 +1,400 @@
+"""
+Comprehensive unit tests for tradedangerous.db.utils functions.
+
+Tests cover:
+  - parse_ts: diverse timestamp format parsing into UTC-naive datetimes
+"""
+from __future__ import annotations
+from datetime import datetime, timezone, timedelta
+import pytest
+import typing
+
+from . import utils
+
+if typing.TYPE_CHECKING:
+    from typing import Any
+
+
+# Far future epoch value: approximately year 10000 in Unix epoch seconds
+# This value exceeds the valid range for datetime.fromtimestamp() on many
+# systems and is used to test out-of-range epoch handling
+FAR_FUTURE_EPOCH = 253402300800
+
+
+class TestParseTs:
+    """Comprehensive tests for parse_ts() function."""
+
+    # Basic test of each type, ensuring it discriminates
+
+    def test_parse_ts_none_returns_none(self) -> None:
+        """parse_ts(None) should return None."""
+        result: datetime | None = utils.parse_ts(None)
+        assert result is None
+
+    def test_parse_ts_naive_datetime_with_microseconds_clears_microseconds(self) -> None:
+        """parse_ts with naive datetime should clear microseconds."""
+        dt = datetime(2025, 1, 15, 10, 30, 45, 123456)
+        result: datetime | None = utils.parse_ts(dt)
+        
+        assert result is not None
+        assert result.year == 2025
+        assert result.month == 1
+        assert result.day == 15
+        assert result.hour == 10
+        assert result.minute == 30
+        assert result.second == 45
+        assert result.microsecond == 0
+
+    def test_parse_ts_aware_datetime_utc_converts_to_naive(self) -> None:
+        """parse_ts with UTC-aware datetime should convert to naive."""
+        dt = datetime(2025, 1, 15, 10, 30, 45, 123456, tzinfo=timezone.utc)
+        result: datetime | None = utils.parse_ts(dt)
+        
+        assert result is not None
+        assert result.tzinfo is None
+        assert result.microsecond == 0
+        assert result == datetime(2025, 1, 15, 10, 30, 45)
+
+    def test_parse_ts_aware_datetime_with_est_offset_converts_to_utc_naive(self) -> None:
+        """parse_ts with EST (-05:00) datetime should convert to UTC then naive."""
+        # EST is UTC-5, so 10:30 EST = 15:30 UTC
+        est = timezone(timedelta(hours=-5))
+        dt = datetime(2025, 1, 15, 10, 30, 45, 123456, tzinfo=est)
+        result: datetime | None = utils.parse_ts(dt)
+        
+        assert result is not None
+        assert result.tzinfo is None
+        assert result.hour == 15  # 10 + 5 hours
+        assert result.microsecond == 0
+
+    def test_parse_ts_aware_datetime_with_positive_offset_converts_to_utc_naive(self) -> None:
+        """parse_ts with UTC+05:30 (IST) datetime should convert to UTC then naive."""
+        # IST is UTC+5:30, so 10:30 IST = 05:00 UTC
+        ist = timezone(timedelta(hours=5, minutes=30))
+        dt = datetime(2025, 1, 15, 10, 30, 45, tzinfo=ist)
+        result: datetime | None = utils.parse_ts(dt)
+        
+        assert result is not None
+        assert result.tzinfo is None
+        assert result.hour == 5  # 10 - 5 = 5
+        assert result.minute == 0  # 30 - 30 = 0
+
+    @pytest.mark.parametrize("epoch,expected_dt", [
+        (0, datetime(1970, 1, 1, 0, 0, 0)),  # epoch start
+        (1, datetime(1970, 1, 1, 0, 0, 1)),  # epoch + 1 second
+        (1*60*60 + 1*60 + 7, datetime(1970, 1, 1, 1, 1, 7)),  # epoch + 1 hour, 1 minute, and 7 seconds
+        (24 * 60 * 60 + 3, datetime(1970, 1, 2, 0, 0, 3)),  # 1 day and 3 seconds
+        (86400, datetime(1970, 1, 2, 0, 0, 0)),
+    ])
+    def test_parse_ts_integer_epoch_converts_to_datetime(self, epoch: int, expected_dt: datetime) -> None:
+        """parse_ts with integer epoch seconds should convert to datetime."""
+        result: datetime | None = utils.parse_ts(epoch)
+        
+        assert result is not None, f"Failed to parse epoch {epoch}"
+        assert result == expected_dt, f"Expected {expected_dt}, got {result} for epoch {epoch}"
+        assert result.microsecond == 0
+
+    @pytest.mark.parametrize("epoch,expected_dt", [
+        (0.0, datetime(1970, 1, 1, 0, 0, 0)),  # epoch start
+        (7200.001, datetime(1970, 1, 1, 2, 0, 0)),  # epoch + 2 hours and some milliseconds
+        (86400.5, datetime(1970, 1, 2, 0, 0, 0)),  # 1 day + 0.5 seconds
+    ])
+    def test_parse_ts_float_epoch_converts_to_datetime(self, epoch: float, expected_dt: datetime) -> None:
+        """parse_ts with float epoch seconds should convert to datetime (microseconds zeroed)."""
+        result: datetime | None = utils.parse_ts(epoch)
+        
+        assert result is not None, f"Failed to parse epoch {epoch}"
+        assert result == expected_dt, f"Expected {expected_dt}, got {result} for epoch {epoch}"
+        assert result.microsecond == 0
+
+    @pytest.mark.parametrize("invalid_epoch", [
+        float('inf'),
+        float('-inf'),
+        float('nan'),
+    ])
+    def test_parse_ts_invalid_epoch_returns_none(self, invalid_epoch: float) -> None:
+        """parse_ts with invalid epoch (inf, nan) should return None."""
+        result: datetime | None = utils.parse_ts(invalid_epoch)
+        assert result is None, f"Expected None for invalid epoch {invalid_epoch}, got {result}"
+
+    def test_parse_ts_out_of_range_epoch_returns_none(self) -> None:
+        """parse_ts with epoch out of valid range should return None."""
+        result = utils.parse_ts(FAR_FUTURE_EPOCH)
+        assert result is None, f"Expected None for out-of-range epoch {FAR_FUTURE_EPOCH}, got {result}"
+
+    @pytest.mark.parametrize("invalid_value", (  # type: ignore[reportUnknownArgumentType]
+        object,
+        object(),
+        True,
+        False,
+        b'1970-01-01T00:00:00',
+        timezone,
+        timezone(timedelta(hours=1)),
+    ))
+    def test_parse_ts_invalid_type_returns_none(self, invalid_value: Any) -> None:
+        """parse_ts with other types should return None."""
+        result: datetime | None = utils.parse_ts(invalid_value)
+        assert result is None, f"Expected None for unexpected types: {invalid_value!r}"
+
+    # String Parsing: Basic Formats
+
+    def test_parse_ts_iso_basic_format(self) -> None:
+        """parse_ts('2026-01-15T10:30:45') should parse ISO format."""
+        result: datetime | None = utils.parse_ts("2026-01-15T10:30:45")
+        
+        assert result is not None
+        assert result == datetime(2026, 1, 15, 10, 30, 45)
+        assert result.microsecond == 0
+
+    def test_parse_ts_iso_with_fractional_seconds(self) -> None:
+        """parse_ts with fractional seconds should discard them (microsecond=0)."""
+        result: datetime | None = utils.parse_ts("2026-01-15T10:30:45.123456")
+        
+        assert result is not None
+        assert result == datetime(2026, 1, 15, 10, 30, 45)
+        assert result.microsecond == 0
+
+    def test_parse_ts_iso_with_partial_fractional_seconds(self) -> None:
+        """parse_ts with partial fractional seconds (.567) should discard them."""
+        result: datetime | None = utils.parse_ts("2026-01-15T10:30:45.567")
+        
+        assert result is not None
+        assert result == datetime(2026, 1, 15, 10, 30, 45)
+        assert result.microsecond == 0
+
+    def test_parse_ts_date_only_format(self) -> None:
+        """parse_ts('2026-01-15') should parse date-only format."""
+        result: datetime | None = utils.parse_ts("2026-01-15")
+        
+        assert result is not None
+        assert result == datetime(2026, 1, 15, 0, 0, 0)
+
+    def test_parse_ts_legacy_space_separated_datetime(self) -> None:
+        """parse_ts('2026-01-15 10:30:45') should parse space-separated format."""
+        result: datetime | None = utils.parse_ts("2026-01-15 10:30:45")
+        
+        assert result is not None
+        assert result == datetime(2026, 1, 15, 10, 30, 45)
+
+    # String Parsing: Timezone Handling
+
+    @pytest.mark.parametrize("input_str,expected_hour,expected_minute", [
+        ("2026-01-15T10:30:45Z", 10, 30),  # uppercase Z
+        ("2026-01-15T10:30:45z", 10, 30),  # lowercase z
+        ("2026-01-15T10:30:45+05:30", 5, 0),  # positive HH:MM
+        ("2026-01-15T10:30:45-08:00", 18, 30),  # negative HH:MM
+        ("2026-01-15T10:30:45+0530", 5, 0),  # positive HHMM no colon
+        ("2026-01-15T10:30:45-0530", 16, 0),  # negative HHMM no colon
+        ("2026-01-15T10:30:45+05", 5, 30),  # positive HH only
+        ("2026-01-15T10:30:45-05", 15, 30),  # negative HH only
+        ("2026-01-15T10:30:45 +05:30", 5, 0),  # space before positive offset
+        ("2026-01-15T10:30:45 -05:30", 16, 0),  # space before negative offset
+    ], ids=[
+        "uppercase-Z",
+        "lowercase-z",
+        "positive-HH:MM",
+        "negative-HH:MM",
+        "positive-HHMM-no-colon",
+        "negative-HHMM-no-colon",
+        "positive-HH-only",
+        "negative-HH-only",
+        "space-before-positive",
+        "space-before-negative",
+    ])
+    def test_parse_ts_timezone_offset_formats(self, input_str: str, expected_hour: int, expected_minute: int) -> None:
+        """Parametrized test for various timezone offset format parsing."""
+        result: datetime | None = utils.parse_ts(input_str)
+        
+        assert result is not None, f"Failed to parse {input_str}"
+        assert result.hour == expected_hour, \
+            f"Expected hour {expected_hour}, got {result.hour} for input {input_str}"
+        assert result.minute == expected_minute, \
+            f"Expected minute {expected_minute}, got {result.minute} for input {input_str}"
+        assert result.tzinfo is None, f"Result should be naive, got tzinfo={result.tzinfo}"
+
+    # String Parsing: Normalization
+
+    def test_parse_ts_z_converted_to_plus_00_00(self) -> None:
+        """parse_ts should convert 'Z' to '+00:00' internally (verified by result)."""
+        result_z: datetime | None = utils.parse_ts("2026-01-15T10:30:45Z")
+        result_plus: datetime | None = utils.parse_ts("2026-01-15T10:30:45+00:00")
+
+        assert result_z is not None
+        assert result_z == result_plus
+
+    def test_parse_ts_hhmm_normalized_to_hh_mm(self) -> None:
+        """parse_ts should normalize +HHMM to +HH:MM format."""
+        result_no_colon: datetime | None = utils.parse_ts("2026-01-15T10:30:45+0530")
+        result_colon: datetime | None = utils.parse_ts("2026-01-15T10:30:45+05:30")
+        
+        assert result_no_colon == result_colon
+
+    def test_parse_ts_space_to_t_conversion(self) -> None:
+        """parse_ts should convert first space between date/time to 'T'."""
+        result = utils.parse_ts("2026-01-15 10:30:45")
+        assert result is not None
+        expected: datetime | None = utils.parse_ts("2026-01-15T10:30:45")
+        
+        assert result == expected
+
+    # Edge Cases
+
+    def test_parse_ts_empty_string_returns_none(self) -> None:
+        """parse_ts('') should return None."""
+        result: datetime | None = utils.parse_ts("")
+        assert result is None
+
+    def test_parse_ts_whitespace_only_string_returns_none(self) -> None:
+        """parse_ts('   ') should return None."""
+        result: datetime | None = utils.parse_ts("   ")
+        assert result is None
+
+    def test_parse_ts_invalid_format_returns_none(self) -> None:
+        """parse_ts with invalid format should return None (no exception)."""
+        result: datetime | None = utils.parse_ts("not a date")
+        assert result is None
+
+    def test_parse_ts_invalid_format_garbage_returns_none(self) -> None:
+        """parse_ts with garbage input should return None."""
+        result: datetime | None = utils.parse_ts("!!!@@@###")
+        assert result is None
+
+    def test_parse_ts_out_of_range_date_feb_30_returns_none(self) -> None:
+        """parse_ts('2026-02-30') should return None (invalid date)."""
+        result: datetime | None = utils.parse_ts("2026-02-30")
+        assert result is None
+
+    def test_parse_ts_leap_year_feb_29(self) -> None:
+        """parse_ts('2024-02-29') should parse (leap year)."""
+        result: datetime | None = utils.parse_ts("2024-02-29")
+        
+        assert result is not None
+        assert result == datetime(2024, 2, 29, 0, 0, 0)
+
+    def test_parse_ts_non_leap_year_feb_29_returns_none(self) -> None:
+        """parse_ts('2023-02-29') should return None (not a leap year)."""
+        result: datetime | None = utils.parse_ts("2023-02-29")
+        assert result is None
+
+    def test_parse_ts_epoch_start(self) -> None:
+        """parse_ts epoch 0 should yield 1970-01-01."""
+        result: datetime | None = utils.parse_ts(0)
+        assert result == datetime(1970, 1, 1, 0, 0, 0)
+
+    def test_parse_ts_negative_epoch_before_1970(self) -> None:
+        """parse_ts with negative epoch (before 1970) may fail on some systems."""
+        result: datetime | None = utils.parse_ts(-86400)  # 1 day before epoch
+        
+        # Negative epochs are not reliably supported on all systems/OSes
+        # Windows in particular may not support dates before 1970
+        # So we just verify that if it works, it's a datetime
+        if result is not None:
+            assert isinstance(result, datetime)
+
+    def test_parse_ts_far_future_year_9999(self) -> None:
+        """parse_ts('9999-12-31') should parse far future dates."""
+        result: datetime | None = utils.parse_ts("9999-12-31")
+        
+        assert result is not None
+        assert result.year == 9999
+        assert result.month == 12
+        assert result.day == 31
+
+    def test_parse_ts_year_1900_boundary(self) -> None:
+        """parse_ts('1900-01-01') should parse historical dates."""
+        result: datetime | None = utils.parse_ts("1900-01-01")
+        
+        assert result is not None
+        assert result.year == 1900
+        assert result.month == 1
+        assert result.day == 1
+
+    # Timezone Arithmetic Verification
+
+    def test_parse_ts_utc_plus_5_from_10_00_yields_05_00_utc(self) -> None:
+        """Verify UTC+05:00 input '10:00' yields UTC '05:00'."""
+        result: datetime | None = utils.parse_ts("2026-01-15T10:00:00+05:00")
+
+        assert result is not None
+        assert result.hour == 5, f"Expected hour 5, got {result.hour}"
+        assert result.minute == 0, f"Expected minute 0, got {result.minute}"
+
+    def test_parse_ts_utc_minus_8_from_10_00_yields_18_00_utc(self) -> None:
+        """Verify UTC-08:00 input '10:00' yields UTC '18:00'."""
+        result: datetime | None = utils.parse_ts("2026-01-15T10:00:00-08:00")
+        
+        assert result is not None
+        assert result.hour == 18, f"Expected hour 18, got {result.hour}"
+        assert result.minute == 0, f"Expected minute 0, got {result.minute}"
+
+    def test_parse_ts_utc_z_from_10_00_yields_10_00_utc(self) -> None:
+        """Verify UTC+00:00 (Z) input '10:00' yields UTC '10:00'."""
+        result: datetime | None = utils.parse_ts("2026-01-15T10:00:00Z")
+        
+        assert result is not None
+        assert result.hour == 10, f"Expected hour 10, got {result.hour}"
+        assert result.minute == 0, f"Expected minute 0, got {result.minute}"
+
+    # Error Handling & Graceful Degradation
+
+    def test_parse_ts_does_not_raise_on_invalid_input(self) -> None:
+        """parse_ts should not raise exceptions for invalid input, return None instead."""
+        # These should all return None without raising
+        assert utils.parse_ts("invalid@#$%") is None, "Expected None for invalid characters"
+        assert utils.parse_ts("2025-13-45") is None, "Expected None for invalid month/day"
+        assert utils.parse_ts("not a timestamp") is None, "Expected None for non-timestamp string"
+
+
+# PARAMETRIZED TESTS: Comprehensive coverage with multiple inputs
+
+class TestParseTs_Parametrized:
+    """Parametrized tests for comprehensive edge case coverage."""
+
+    @pytest.mark.parametrize("input_str,expected_hour,expected_minute", [
+        ("2026-01-15T12:00:00+00:00", 12, 0),
+        ("2026-01-15T12:00:00+01:00", 11, 0),
+        ("2026-01-15T12:00:00-01:00", 13, 0),
+        ("2026-01-15T12:00:00+05:30", 6, 30),
+        ("2026-01-15T12:00:00-05:30", 17, 30),
+    ])
+    def test_parse_ts_various_offsets(self, input_str: str, expected_hour: int, expected_minute: int) -> None:
+        """Parametrized test for various UTC offset conversions."""
+        result: datetime | None = utils.parse_ts(input_str)
+        
+        assert result is not None, f"Failed to parse {input_str}"
+        assert result.hour == expected_hour, \
+            f"Expected hour {expected_hour}, got {result.hour} for {input_str}"
+        assert result.minute == expected_minute, \
+            f"Expected minute {expected_minute}, got {result.minute} for {input_str}"
+
+    @pytest.mark.parametrize("input_val,should_succeed", [
+        ("2026-01-15",                True),
+        ("2026-01-15T10:30:45",       True),
+        ("2026-01-15T10:30:45Z",      True),
+        ("2026-01-15T10:30:45+05:00", True),
+        ("invalid",                   False),
+        ("",                          False),
+        ("2026-13-01",                False),
+        ("2026-01-32",                False),
+    ])
+    def test_parse_ts_string_validity(self, input_val: str, should_succeed: bool) -> None:
+        """Parametrized test for string validity checks."""
+        result: datetime | None = utils.parse_ts(input_val)
+        
+        if should_succeed:
+            assert result is not None, f"Expected success for {input_val}"
+        else:
+            assert result is None, f"Expected None for {input_val}"
+
+    @pytest.mark.parametrize("epoch_val", [
+        0,
+        1,
+        86400,
+    ])
+    def test_parse_ts_valid_epochs(self, epoch_val: int) -> None:
+        """Parametrized test for various valid epoch values."""
+        result: datetime | None = utils.parse_ts(epoch_val)
+        
+        assert result is not None, f"Failed to parse epoch {epoch_val}"
+        assert isinstance(result, datetime), f"Expected datetime, got {type(result)}"
+        assert result.microsecond == 0, f"Expected microsecond=0, got {result.microsecond}"

--- a/tradedangerous/db/utils.py
+++ b/tradedangerous/db/utils.py
@@ -11,15 +11,28 @@
 from __future__ import annotations
 
 import os
-from datetime import datetime, timezone
-from typing import Optional, Iterable, Mapping, Sequence, Literal, Callable, Dict, Any
 import re
+from datetime import datetime, timezone, timedelta
+from typing import Optional, Iterable, Mapping, Sequence, Literal, Callable, Dict, Any
 
 from sqlalchemy import Table, text, func, and_, bindparam
 from sqlalchemy.orm import Session
 from sqlalchemy.dialects.sqlite import insert as sqlite_insert
 from sqlalchemy.dialects.mysql import insert as mysql_insert
 from sqlalchemy.sql.elements import ClauseElement
+
+
+# --------------------------------------------------------
+# Module-level constants
+# --------------------------------------------------------
+
+# Pre-compiled regex for ISO-like datetime parsing
+# Matches: YYYY-MM-DD[T| ]HH:MM:SS[.fff][Z|(+|-)HH[[:]MM]]
+_DATETIME_PATTERN = re.compile(
+    r"^(?P<date>\d{4}-\d{2}-\d{2})"
+    r"(?:[T ](?P<time>\d{2}:\d{2}:\d{2})(?:\.(?P<frac>\d{1,6}))?)?"
+    r"(?:(?P<tz_sign>[+-])(?P<tz_hour>\d{2})(?::?(?P<tz_min>\d{2}))?)?$"
+)
 
 
 # --------------------------------------------------------
@@ -217,12 +230,14 @@ def is_sqlite(session: Session) -> bool:
     except Exception:
         return False
 
+
 def is_mysql(session: Session) -> bool:
     try:
         name = session.get_bind().dialect.name.lower()
         return name in ("mysql", "mariadb")
     except Exception:
         return False
+
 
 def sqlite_set_bulk_pragmas(session: Session) -> None:
     """
@@ -237,6 +252,7 @@ def sqlite_set_bulk_pragmas(session: Session) -> None:
     conn.execute(text("PRAGMA temp_store=MEMORY"))
     # Negative cache_size is KiB; -65536 ≈ 64 MiB page cache
     conn.execute(text("PRAGMA cache_size=-65536"))
+
 
 def sqlite_upsert_modified(
     session: Session,
@@ -276,6 +292,7 @@ def sqlite_upsert_modified(
     
     session.execute(stmt, rows)
 
+
 def sqlite_upsert_simple(
     session: Session,
     table: Table,
@@ -303,6 +320,7 @@ def sqlite_upsert_simple(
     
     session.execute(stmt, rows)
 
+
 def mysql_set_bulk_session(session: Session) -> None:
     """
     Per-session tuning for bulk imports (MariaDB/MySQL).
@@ -326,6 +344,7 @@ def mysql_set_bulk_session(session: Session) -> None:
     except Exception:
         # Not always allowed; silently ignore.
         pass
+
 
 def mysql_upsert_modified(
     session: Session,
@@ -385,6 +404,7 @@ def mysql_upsert_simple(
     
     stmt = ins.on_duplicate_key_update(**set_map)
     session.execute(stmt, rows)
+
 
 # -----------------------------------------------------------------------------
 # csvexport helpers (schema introspection)
@@ -461,8 +481,6 @@ def get_unique_columns(session, table_name: str) -> list[str]:
         return list(set(cols))
 
 
-
-
 def get_foreign_keys(session, table_name: str) -> list[dict]:
     """
     Return list of foreign key mappings:
@@ -521,7 +539,6 @@ def get_foreign_keys(session, table_name: str) -> list[dict]:
         return fkeys
 
 
-
 # -----------------------------------------------------------------------------
 # Timestamp Helpers
 # -----------------------------------------------------------------------------
@@ -556,7 +573,18 @@ def age_in_days(session: Session, column: ClauseElement) -> ClauseElement:
     # DATE(NOW()) - DATE(column) yields an integer in many SQL dialects.
     return func.date(func.now()) - func.date(column)
 
-def parse_ts(value) -> Optional[datetime]:
+
+def normalize_dt(dt: datetime) -> datetime:
+    """ normalizes a datetime object to a single standard, currently
+        that is a *naive* representation without microseconds. """
+    if dt.tzinfo:
+        if dt.tzinfo != timezone.utc:
+            dt = dt.astimezone(timezone.utc)
+        dt = dt.replace(tzinfo=None)
+    return dt.replace(microsecond=0)
+
+
+def parse_ts(value: datetime | int | float | str | Any) -> datetime | None:
     """
     Parse timestamp values into UTC-naive datetime (microsecond=0).
 
@@ -573,103 +601,91 @@ def parse_ts(value) -> Optional[datetime]:
       - 'Z' -> '+00:00'
       - '+HHMM' -> '+HH:MM'
       - '+HH' -> '+HH:00'
-      - single space between date/time -> replaced with 'T'
       - Aware datetimes -> converted to UTC then made naive
+      - Fractional seconds are discarded
     """
-    if value is None:
+    match value:
+        case None | bool():
+            return None
+        
+        case datetime() as dt:
+            return normalize_dt(dt)
+        
+        case int() | float():
+            # Epoch seconds (int or float)
+            try:
+                return normalize_dt(datetime.fromtimestamp(float(value), tz=timezone.utc))
+            except (ValueError, OverflowError, OSError):
+                return None
+        
+        case str():
+            return parse_ts_string(value)
+        
+        case _:
+            return None
+
+
+def parse_ts_string(value: str) -> datetime | None:
+    """
+    Parse ISO and near-ISO timestamp strings.
+    Assumes normalized to UTC if no timezone specified.
+    
+    Fast-path: fromisoformat() for standard ISO formats.
+    Fallback: regex validation + manual offset parsing for edge cases.
+    """
+    s = value.strip()
+    if not s:
+        return None
+    
+    # Single-pass normalization of common variants
+    # Handle: 'Z'/'z' -> '+00:00', space before offset, T vs space separator
+    if s[-1] in ('Z', 'z'):
+        s = s[:-1] + '+00:00'
+    
+    # Normalize spaces: T separator and optional space before offset
+    # "YYYY-MM-DD HH:MM:SS+HH:MM" or "YYYY-MM-DD HH:MM:SS +HH:MM"
+    if ' ' in s:
+        # Replace first space (date-time separator) with T if needed
+        if 'T' not in s:
+            s = s.replace(' ', 'T', 1)
+        # Remove trailing spaces before offset (e.g., "...SS +HH:MM" -> "...SS+HH:MM")
+        s = s.replace(' ', '')
+    
+    # Fast-path: Python 3.11+ fromisoformat is highly optimized
+    try:
+        dt = datetime.fromisoformat(s)
+        return normalize_dt(dt)
+    except ValueError:
+        pass
+    
+    # Fallback: regex for non-standard but parseable formats
+    # Validates structure before attempting strptime (reduces overhead)
+    m = _DATETIME_PATTERN.match(s)
+    if not m:
         return None
 
-    # datetime input
-    if isinstance(value, datetime):
-        dt = value
-        if dt.tzinfo is not None:
-            dt = dt.astimezone(timezone.utc).replace(tzinfo=None)
-        return dt.replace(microsecond=0)
-
-    # epoch seconds
-    if isinstance(value, (int, float)):
-        try:
-            return datetime.utcfromtimestamp(float(value)).replace(microsecond=0)
-        except (ValueError, TypeError, OverflowError, OSError):
-            return None
-
-    # string input
-    if isinstance(value, str):
-        s = value.strip()
-        if not s:
-            return None
-
-        # Normalise timezone notations
-        if s.endswith(("Z", "z")):
-            s = s[:-1] + "+00:00"
-
-        # Replace the first space between date/time with 'T' (legacy form)
-        if " " in s and "T" not in s:
-            s = s.replace(" ", "T", 1)
-
-        # Remove any remaining spaces (commonly before the offset)
-        if "T" in s and " " in s:
-            s = s.replace(" ", "")
-
-        # Fast-path parse for the formats we actually see from upstream:
-        #   YYYY-MM-DD
-        #   YYYY-MM-DDTHH:MM:SS[.fff][Z|(+|-)HH[[:]MM]]
-        #
-        # We discard fractional seconds because we always return microsecond=0.
-        m = re.match(
-            r"^(?P<date>\d{4}-\d{2}-\d{2})"
-            r"(?:T(?P<time>\d{2}:\d{2}:\d{2})(?:\.(?P<frac>\d{1,6}))?)?"
-            r"(?:(?P<tz_sign>[+-])(?P<tz_hour>\d{2})(?::?(?P<tz_min>\d{2}))?)?$",
-            s,
+    date_str = m.group('date')
+    time_str = m.group('time')
+    
+    try:
+        dt = datetime.strptime(
+            f'{date_str}T{time_str}' if time_str else date_str,
+            '%Y-%m-%dT%H:%M:%S' if time_str else '%Y-%m-%d'
         )
-        if m:
-            date_s = m.group("date")
-            time_s = m.group("time")
-            tz_sign = m.group("tz_sign")
-            tz_hour = m.group("tz_hour")
-            tz_min = m.group("tz_min")
-
-            try:
-                if time_s:
-                    dt = datetime.strptime(f"{date_s}T{time_s}", "%Y-%m-%dT%H:%M:%S")
-                else:
-                    dt = datetime.strptime(date_s, "%Y-%m-%d")
-            except ValueError:
-                dt = None
-
-            if dt is not None:
-                if tz_sign and tz_hour:
-                    from datetime import timedelta  # local import to avoid module-level churn
-
-                    hours = int(tz_hour)
-                    mins = int(tz_min) if tz_min else 0
-
-                    # dt_local = dt_utc + offset  => dt_utc = dt_local - offset
-                    offset = timedelta(hours=hours, minutes=mins)
-                    if tz_sign == "+":
-                        dt = dt - offset
-                    else:
-                        dt = dt + offset
-
-                return dt.replace(microsecond=0)
-
-        # Fallback: try ISO parse (best-effort)
-        try:
-            dt = datetime.fromisoformat(s)
-            if dt.tzinfo is not None:
-                dt = dt.astimezone(timezone.utc).replace(tzinfo=None)
-            return dt.replace(microsecond=0)
-        except (ValueError, TypeError):
-            pass
-
-        # Legacy / naive formats (assume UTC)
-        for fmt in ("%Y-%m-%dT%H:%M:%S", "%Y-%m-%d %H:%M:%S", "%Y-%m-%d"):
-            try:
-                return datetime.strptime(s, fmt).replace(microsecond=0)
-            except ValueError:
-                continue
-
-    return None
+    except ValueError:
+        return None
+    
+    # Apply timezone offset if present
+    tz_sign = m.group('tz_sign')
+    tz_hour = m.group('tz_hour')
+    if tz_sign and tz_hour:
+        hours = int(tz_hour)
+        mins = int(m.group('tz_min') or 0)
+        offset = timedelta(hours=hours, minutes=mins)
+        # Convert from local time with offset to UTC
+        dt = (dt - offset) if tz_sign == '+' else (dt + offset)
+    
+    return normalize_dt(dt)
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
timestamp parsing shows up as a sizeable portion of the import process, so I did a little bit of a hygiene pass on it

- added unit tests first to ensure I captured the expected functionality
(the code specifically produces timezone-naive datetimes which was a surprise)
- added `research/perf/...` benchmarking tools for future use,
- ran a before-after benchmark showing a significant perf improvement, especially in the more common paths,
- - plugin system could eventually use a general pass to surface this kind of "tell me how to" rather than the current "try to figure out what it might be like" on a per-row basis,
- moved the string-parse version into its own helper method so it can be called directly when you *know* you have a string,
- optimized the string-parse version:
- - the regex was being compiled per string-match operation: moved to module load with a re.compile,
- - lots of string-search manip was being done redundantly at cost,
-  wrote benchmarker: See research/perf/bench_parse_ts.py

Benchmarks on i7 13 gen:

before:
```
    $ python ./research/perf/bench_parse_ts.py
    Iteration 5,003 iters took 94.265s, bench 94.283s
    ex-best: 3.007ms, best: 3.046ms, avg: 18.815ms, worst: 166.830ms, ex-worst: 167.929ms,
    p10: 15.679ms, p25: 15.745ms, p50: 16.125ms, p90: 31.464ms, p99: 33.577ms,
```

after:
```
    $ python ./research/perf/bench_parse_ts.py
    Iteration 5,003 iters took 53.305s, bench 53.315s
    ex-best: 0.000ms, best: 0.000ms, avg: 10.652ms, worst: 27.355ms, ex-worst: 31.672ms,
    p10: 0.000ms, p25: 9.012ms, p50: 11.756ms, p90: 15.937ms, p99: 21.487ms,
```