### PR TITLE
set a timeout on edsm HTTP calls

### DIFF
--- a/tradedangerous/misc/edsm.py
+++ b/tradedangerous/misc/edsm.py
@@ -49,7 +49,7 @@ class EDSMQueryBase:
             self.params[k] = v
     
     def fetch(self):
-        res = requests.get(self.url, self.params)
+        res = requests.get(self.url, self.params, timeout=10.0)
         self.status = res.status_code
         
         try:


### PR DESCRIPTION
I noticed this while tracing through tradedangerous/misc/edsm.py. Set a timeout on edsm HTTP calls. Network calls without a timeout can hang a worker indefinitely. I kept the patch small and re-ran syntax checks after applying it.