### PR TITLE
Fix/331 gui data initialisation

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,6 @@ If you want to give Trade Dangerous a try, look no further than the [Setup Guide
 
 Curious about programming with Trade Dangerous/Python? Take the [Python Quick Peek](https://github.com/eyeonus/Trade-Dangerous/wiki/Python-Quick-Peek "Python Quick Peek").
 
-# AI-assisted development disclosure
+### AI-assisted development disclosure
 
 Trade Dangerous has been developed partly by humans working without AI assistance and partly with AI assistance under human direction and review. We disclose this so users and contributors can make an informed choice about AI-assisted software.

--- a/README.md
+++ b/README.md
@@ -62,3 +62,7 @@ Note that it could have just told us to pick up 6 Titanium (the max we could aff
 If you want to give Trade Dangerous a try, look no further than the [Setup Guide](https://github.com/eyeonus/Trade-Dangerous/wiki/Setup-Guide "Setup Guide") and the [User Guide](https://github.com/eyeonus/Trade-Dangerous/wiki/User-Guide "User Guide").
 
 Curious about programming with Trade Dangerous/Python? Take the [Python Quick Peek](https://github.com/eyeonus/Trade-Dangerous/wiki/Python-Quick-Peek "Python Quick Peek").
+
+# AI-assisted development disclosure
+
+Trade Dangerous has been developed partly by humans working without AI assistance and partly with AI assistance under human direction and review. We disclose this so users and contributors can make an informed choice about AI-assisted software.

--- a/tests/test_gui_first_run.py
+++ b/tests/test_gui_first_run.py
@@ -1,0 +1,212 @@
+import asyncio
+from functools import partial
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+import tradedangerous.guiapp.import_view as import_view
+import tradedangerous.guiapp.shell as shell_module
+from tradedangerous.guiapp.import_view import ImportWorkspace
+from tradedangerous.guiapp.profiles import GuiStore
+from tradedangerous.guiapp.session import ExecutionState, ExecutionStatus
+from tradedangerous.guiapp.shell import AppShell
+
+
+def _fake_element(*, value=None):
+    element = MagicMock()
+    element.value = value
+    element.text = ''
+    element.disabled = False
+    element.visible = True
+    element.classes.return_value = element
+    element.style.return_value = element
+    element.props.return_value = element
+    element.tooltip.return_value = element
+    element.disable.side_effect = (
+        lambda: setattr(element, 'disabled', True) or element
+    )
+    element.enable.side_effect = (
+        lambda: setattr(element, 'disabled', False) or element
+    )
+    element.__enter__.return_value = element
+    return element
+
+
+def _fake_ui():
+    fake_ui = SimpleNamespace(
+        labels=[],
+        checkbox_labels=[],
+        links=[],
+    )
+    fake_ui.dialog = MagicMock(side_effect=lambda: _fake_element())
+    fake_ui.card = MagicMock(side_effect=lambda: _fake_element())
+    fake_ui.column = MagicMock(side_effect=lambda: _fake_element())
+    fake_ui.row = MagicMock(side_effect=lambda: _fake_element())
+    fake_ui.label = MagicMock(
+        side_effect=lambda value: (
+            fake_ui.labels.append(value) or _fake_element()
+        )
+    )
+    fake_ui.link = MagicMock(
+        side_effect=lambda text, target, **kwargs: (
+            fake_ui.links.append((text, target, kwargs))
+            or _fake_element()
+        )
+    )
+    fake_ui.checkbox = MagicMock(
+        side_effect=lambda label, **kwargs: (
+            fake_ui.checkbox_labels.append(label)
+            or _fake_element(value=kwargs.get('value'))
+        )
+    )
+    fake_ui.button = MagicMock(side_effect=lambda *_args, **_kwargs: _fake_element())
+    fake_ui.space = MagicMock(side_effect=lambda: _fake_element())
+    return fake_ui
+
+
+async def _complete_import(
+    *,
+    final_status,
+    session,
+    request,
+    refresh_ui,
+    window_close_state,
+):
+    session.set_execution(
+        status=final_status,
+        active_command=request.command,
+    )
+
+
+def _make_shell(monkeypatch, *, data_mode, selected_command='run'):
+    store = GuiStore.default()
+    store.data_mode = data_mode
+    store.selected_command = selected_command
+    monkeypatch.setattr(shell_module, 'get_gui_search_service', object)
+    shell = AppShell(store)
+    shell.command_select = _fake_element(
+        value=shell.session.selected_command,
+    )
+    shell._refresh_ui = lambda: None
+    return shell, store
+
+
+def test_unfinished_setup_selects_import_workspace(monkeypatch):
+    shell, store = _make_shell(monkeypatch, data_mode=None)
+    assert shell.session.selected_command == 'import'
+    assert store.selected_command == 'import'
+    assert shell.session.draft is store.drafts['import']
+
+
+def test_unfinished_setup_rejects_ordinary_command_navigation(monkeypatch):
+    shell, store = _make_shell(monkeypatch, data_mode=None)
+    saved = []
+    monkeypatch.setattr(shell_module, 'save_gui_store', saved.append)
+    shell.command_select.value = 'run'
+    asyncio.run(
+        shell._on_command_changed(SimpleNamespace(value='run'))
+    )
+    assert shell.session.selected_command == 'import'
+    assert store.selected_command == 'import'
+    assert shell.command_select.value == 'import'
+    assert saved == []
+
+
+@pytest.mark.parametrize('data_mode', ['crowdsourced', 'solo'])
+def test_established_data_mode_retains_normal_navigation(
+    monkeypatch,
+    data_mode,
+):
+    shell, store = _make_shell(
+        monkeypatch,
+        data_mode=data_mode,
+        selected_command='run',
+    )
+    saved = []
+    monkeypatch.setattr(shell_module, 'save_gui_store', saved.append)
+    asyncio.run(
+        shell._on_command_changed(SimpleNamespace(value='market'))
+    )
+    assert shell.session.selected_command == 'market'
+    assert store.selected_command == 'market'
+    assert saved == [store]
+
+
+@pytest.mark.parametrize(
+    (
+        'final_status',
+        'request_solo',
+        'expected_mode',
+        'expected_disabled',
+    ),
+    [
+        (ExecutionStatus.SUCCEEDED, False, 'crowdsourced', False),
+        (ExecutionStatus.SUCCEEDED, True, 'solo', False),
+        (ExecutionStatus.FAILED, False, None, True),
+        (ExecutionStatus.IDLE, False, None, True),
+    ],
+)
+def test_initial_import_result_controls_navigation_gate(
+    monkeypatch,
+    final_status,
+    request_solo,
+    expected_mode,
+    expected_disabled,
+):
+    shell, store = _make_shell(monkeypatch, data_mode=None)
+    if request_solo:
+        shell.session.draft.main_values['solo'] = True
+    saved = []
+    monkeypatch.setattr(
+        shell_module,
+        'run_import_execution',
+        partial(_complete_import, final_status=final_status),
+    )
+    monkeypatch.setattr(shell_module, 'save_gui_store', saved.append)
+    asyncio.run(shell._on_execute_command())
+    assert store.data_mode == expected_mode
+    assert shell.command_select.disabled is expected_disabled
+    shell.command_select.value = 'run'
+    asyncio.run(
+        shell._on_command_changed(SimpleNamespace(value='run'))
+    )
+    assert shell.session.selected_command == (
+        'import' if expected_disabled else 'run'
+    )
+
+
+def test_first_run_import_guidance_uses_existing_solo_option(monkeypatch):
+    fake_ui = _fake_ui()
+    monkeypatch.setattr(import_view, 'ui', fake_ui)
+    workspace = ImportWorkspace(
+        GuiStore.default().get_or_create_draft('import'),
+        ExecutionState(),
+        initial_setup=True,
+        on_changed=lambda: None,
+        on_execute=lambda: None,
+        on_arm_stop=lambda: None,
+        on_cancel_stop=lambda: None,
+        on_stop=lambda: None,
+    )
+    workspace.build()
+    guidance = ' '.join(fake_ui.labels)
+    assert 'Crowdsourced' in fake_ui.labels
+    assert 'Solo' in fake_ui.labels
+    assert 'normal Trade Dangerous Import' in guidance
+    assert 'schema and base data' in guidance
+    assert 'recommended and supported workflow' in guidance
+    assert 'another data source' in guidance
+    assert fake_ui.links == [
+        ('EDMC + UpdateTD', import_view.UPDATE_TD_URL, {'new_tab': True}),
+    ]
+    assert fake_ui.checkbox_labels == [
+        'All',
+        'Clean',
+        'Optimize',
+        'Force',
+        'Solo',
+        'Purge',
+        '7 Days',
+        'Units',
+    ]

--- a/tests/test_gui_first_run.py
+++ b/tests/test_gui_first_run.py
@@ -29,6 +29,9 @@ def _fake_element(*, value=None):
     element.enable.side_effect = (
         lambda: setattr(element, 'disabled', False) or element
     )
+    element.set_visibility.side_effect = (
+        lambda visible: setattr(element, 'visible', visible) or element
+    )
     element.__enter__.return_value = element
     return element
 
@@ -90,6 +93,30 @@ def _make_shell(monkeypatch, *, data_mode, selected_command='run'):
     )
     shell._refresh_ui = lambda: None
     return shell, store
+
+
+def _build_import_workspace(
+    monkeypatch,
+    *,
+    initial_setup,
+    draft=None,
+):
+    fake_ui = _fake_ui()
+    monkeypatch.setattr(import_view, 'ui', fake_ui)
+    if draft is None:
+        draft = GuiStore.default().get_or_create_draft('import')
+    workspace = ImportWorkspace(
+        draft,
+        ExecutionState(),
+        initial_setup=initial_setup,
+        on_changed=lambda: None,
+        on_execute=lambda: None,
+        on_arm_stop=lambda: None,
+        on_cancel_stop=lambda: None,
+        on_stop=lambda: None,
+    )
+    workspace.build()
+    return workspace
 
 
 def test_unfinished_setup_selects_import_workspace(monkeypatch):
@@ -210,3 +237,199 @@ def test_first_run_import_guidance_uses_existing_solo_option(monkeypatch):
         '7 Days',
         'Units',
     ]
+
+
+def test_incomplete_setup_shows_retained_onboarding_card(monkeypatch):
+    workspace = _build_import_workspace(
+        monkeypatch,
+        initial_setup=True,
+    )
+    assert workspace.onboarding_card.visible is True
+
+
+def test_running_import_hides_only_onboarding_and_retains_widgets(monkeypatch):
+    workspace = _build_import_workspace(
+        monkeypatch,
+        initial_setup=True,
+    )
+    retained_widgets = (
+        workspace.onboarding_card,
+        workspace.status_label,
+        workspace.parent_label,
+        workspace.child_label,
+        workspace.log_label,
+    )
+    running = ExecutionState(
+        status=ExecutionStatus.RUNNING,
+        active_command='import',
+        import_status_text='Import running',
+        import_log_lines=['progress line'],
+    )
+    workspace.refresh_onboarding(initial_setup=True, running=True)
+    workspace.refresh(running)
+    workspace.refresh(running)
+    assert workspace.onboarding_card.visible is False
+    assert workspace.status_label.text == 'Import running'
+    assert workspace.log_label.text == 'progress line'
+    assert retained_widgets == (
+        workspace.onboarding_card,
+        workspace.status_label,
+        workspace.parent_label,
+        workspace.child_label,
+        workspace.log_label,
+    )
+
+
+@pytest.mark.parametrize(
+    ('solo', 'expected_mode'),
+    [
+        (False, 'crowdsourced'),
+        (True, 'solo'),
+    ],
+)
+def test_successful_initial_import_hides_onboarding_from_start_to_completion(
+    monkeypatch,
+    solo,
+    expected_mode,
+):
+    shell, store = _make_shell(monkeypatch, data_mode=None)
+    if solo:
+        shell.session.draft.main_values['solo'] = True
+    workspace = _build_import_workspace(
+        monkeypatch,
+        initial_setup=True,
+        draft=shell.session.draft,
+    )
+    shell.import_workspace = workspace
+    workspace.onboarding_card.set_visibility.reset_mock()
+    retained_widgets = (
+        workspace.status_label,
+        workspace.log_label,
+    )
+
+    async def complete_import(
+        *,
+        session,
+        request,
+        refresh_ui,
+        window_close_state,
+    ):
+        assert workspace.onboarding_card.visible is False
+        assert store.data_mode is None
+        assert bool(request.main_values.get('solo')) is solo
+        session.set_execution(
+            status=ExecutionStatus.RUNNING,
+            active_command='import',
+            import_status_text='Import running',
+            import_log_lines=['working'],
+        )
+        workspace.refresh(session.execution)
+        assert workspace.onboarding_card.visible is False
+        session.set_execution(
+            status=ExecutionStatus.SUCCEEDED,
+            active_command='import',
+            import_status_text='Import complete',
+            import_log_lines=['working', 'done'],
+        )
+        workspace.refresh(session.execution)
+
+    saved = []
+    monkeypatch.setattr(shell_module, 'run_import_execution', complete_import)
+    monkeypatch.setattr(shell_module, 'save_gui_store', saved.append)
+    asyncio.run(shell._on_execute_command())
+    assert store.data_mode == expected_mode
+    assert workspace.onboarding_card.visible is False
+    assert all(
+        visibility_call.args == (False,)
+        for visibility_call in (
+            workspace.onboarding_card.set_visibility.call_args_list
+        )
+    )
+    assert workspace.status_label.text == 'Import complete'
+    assert workspace.log_label.text == 'working\ndone'
+    assert shell.import_workspace is workspace
+    assert retained_widgets == (
+        workspace.status_label,
+        workspace.log_label,
+    )
+    assert saved == [store]
+
+
+@pytest.mark.parametrize(
+    'status_text',
+    ['Import failed.', 'Import stopped.'],
+    ids=['failed', 'stopped'],
+)
+def test_unsuccessful_initial_import_restores_onboarding(
+    monkeypatch,
+    status_text,
+):
+    shell, store = _make_shell(monkeypatch, data_mode=None)
+    workspace = _build_import_workspace(
+        monkeypatch,
+        initial_setup=True,
+        draft=shell.session.draft,
+    )
+    shell.import_workspace = workspace
+    workspace.onboarding_card.set_visibility.reset_mock()
+
+    async def fail_import(
+        *,
+        session,
+        request,
+        refresh_ui,
+        window_close_state,
+    ):
+        assert workspace.onboarding_card.visible is False
+        session.set_execution(
+            status=ExecutionStatus.RUNNING,
+            active_command=request.command,
+        )
+        workspace.refresh(session.execution)
+        session.set_execution(
+            status=ExecutionStatus.FAILED,
+            active_command=request.command,
+            import_status_text=status_text,
+        )
+        workspace.refresh(session.execution)
+
+    save_store = MagicMock()
+    monkeypatch.setattr(shell_module, 'run_import_execution', fail_import)
+    monkeypatch.setattr(shell_module, 'save_gui_store', save_store)
+    asyncio.run(shell._on_execute_command())
+    assert store.data_mode is None
+    assert workspace.onboarding_card.visible is True
+    assert workspace.onboarding_card.set_visibility.call_args_list[0].args == (
+        False,
+    )
+    assert workspace.onboarding_card.set_visibility.call_args_list[-1].args == (
+        True,
+    )
+    assert workspace.status_label.text == status_text
+    assert shell.import_workspace is workspace
+    save_store.assert_not_called()
+
+
+@pytest.mark.parametrize('data_mode', ['crowdsourced', 'solo'])
+def test_established_installation_never_shows_import_onboarding(
+    monkeypatch,
+    data_mode,
+):
+    workspace = _build_import_workspace(
+        monkeypatch,
+        initial_setup=(data_mode is None),
+    )
+    assert workspace.onboarding_card.visible is False
+    for status in (
+        ExecutionStatus.IDLE,
+        ExecutionStatus.RUNNING,
+        ExecutionStatus.FAILED,
+    ):
+        workspace.refresh(
+            ExecutionState(status=status, active_command='import'),
+        )
+        workspace.refresh_onboarding(
+            initial_setup=(data_mode is None),
+            running=status is ExecutionStatus.RUNNING,
+        )
+        assert workspace.onboarding_card.visible is False

--- a/tests/test_gui_import_runtime.py
+++ b/tests/test_gui_import_runtime.py
@@ -3,6 +3,7 @@ from queue import Empty
 from types import SimpleNamespace
 
 import tradedangerous.guiapp.import_runtime as import_runtime
+import tradedangerous.guiapp.shell as shell_module
 from tradedangerous.guiapp.import_runtime import (
     ImportCommandProcess,
     ImportMonitor,
@@ -16,6 +17,7 @@ from tradedangerous.guiapp.import_runtime import (
 )
 from tradedangerous.guiapp.profiles import CommandDraft, GuiStore
 from tradedangerous.guiapp.session import ExecutionStatus, SessionState
+from tradedangerous.guiapp.shell import AppShell
 from tradedangerous.guiapp.td_exec import GuiCommandResult
 
 class _Runner:
@@ -78,6 +80,60 @@ class _ImportRunner:
     
     def close(self):
         return None
+
+def _run_import_mode_case(
+    monkeypatch,
+    *,
+    data_mode,
+    request_solo,
+    final_status,
+    draft_solo_after_start=None,
+):
+    store = GuiStore.default()
+    store.data_mode = data_mode
+    store.selected_command = 'import'
+    store.drafts['import'] = CommandDraft(
+        main_values={'solo': True} if request_solo else {},
+    )
+    session = SessionState.from_store(store)
+    shell = AppShell.__new__(AppShell)
+    shell.store = store
+    shell.session = session
+    shell.window_close_state = None
+    executed_requests = []
+    saved_modes = []
+
+    async def _fake_run_import_execution(
+        *,
+        session,
+        request,
+        refresh_ui,
+        window_close_state,
+    ):
+        executed_requests.append(request)
+        if draft_solo_after_start is True:
+            session.draft.main_values['solo'] = True
+        elif draft_solo_after_start is False:
+            session.draft.main_values.pop('solo', None)
+        session.set_execution(
+            status=final_status,
+            active_command='import',
+        )
+
+    monkeypatch.setattr(
+        shell_module,
+        'run_import_execution',
+        _fake_run_import_execution,
+    )
+    monkeypatch.setattr(
+        shell_module,
+        'save_gui_store',
+        lambda current_store: saved_modes.append(current_store.data_mode),
+    )
+
+    asyncio.run(shell._on_execute_command())
+
+    return store, executed_requests[0], saved_modes
 
 def test_build_import_request_copies_draft_fields():
     draft = CommandDraft(
@@ -184,3 +240,74 @@ def test_run_import_execution_clears_native_close_state_on_finished_before_resul
         ('mark_running', 'import', 'import', 4321),
         ('clear',),
     ]
+
+def test_initial_successful_normal_import_establishes_crowdsourced(monkeypatch):
+    store, request, saved_modes = _run_import_mode_case(
+        monkeypatch,
+        data_mode=None,
+        request_solo=False,
+        final_status=ExecutionStatus.SUCCEEDED,
+    )
+
+    assert request.main_values.get('solo') is None
+    assert store.data_mode == 'crowdsourced'
+    assert saved_modes == ['crowdsourced']
+
+def test_initial_successful_solo_import_establishes_solo(monkeypatch):
+    store, request, saved_modes = _run_import_mode_case(
+        monkeypatch,
+        data_mode=None,
+        request_solo=True,
+        final_status=ExecutionStatus.SUCCEEDED,
+    )
+
+    assert request.main_values['solo'] is True
+    assert store.data_mode == 'solo'
+    assert saved_modes == ['solo']
+
+def test_initial_failed_import_leaves_data_mode_unset(monkeypatch):
+    store, _request, saved_modes = _run_import_mode_case(
+        monkeypatch,
+        data_mode=None,
+        request_solo=False,
+        final_status=ExecutionStatus.FAILED,
+    )
+
+    assert store.data_mode is None
+    assert saved_modes == []
+
+def test_later_solo_import_does_not_change_crowdsourced_mode(monkeypatch):
+    store, _request, saved_modes = _run_import_mode_case(
+        monkeypatch,
+        data_mode='crowdsourced',
+        request_solo=True,
+        final_status=ExecutionStatus.SUCCEEDED,
+    )
+
+    assert store.data_mode == 'crowdsourced'
+    assert saved_modes == []
+
+def test_later_normal_import_does_not_change_solo_mode(monkeypatch):
+    store, _request, saved_modes = _run_import_mode_case(
+        monkeypatch,
+        data_mode='solo',
+        request_solo=False,
+        final_status=ExecutionStatus.SUCCEEDED,
+    )
+
+    assert store.data_mode == 'solo'
+    assert saved_modes == []
+
+def test_initial_import_mode_uses_request_snapshot(monkeypatch):
+    store, request, saved_modes = _run_import_mode_case(
+        monkeypatch,
+        data_mode=None,
+        request_solo=False,
+        final_status=ExecutionStatus.SUCCEEDED,
+        draft_solo_after_start=True,
+    )
+
+    assert request.main_values.get('solo') is None
+    assert store.drafts['import'].main_values['solo'] is True
+    assert store.data_mode == 'crowdsourced'
+    assert saved_modes == ['crowdsourced']

--- a/tests/test_gui_issue_331.py
+++ b/tests/test_gui_issue_331.py
@@ -1,0 +1,114 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+import tradedangerous.guiapp.shell as shell_module
+from tradedangerous.guiapp.journal_import import JournalFacts
+from tradedangerous.guiapp.profiles import GuiStore
+from tradedangerous.guiapp.session import ExecutionStatus
+from tradedangerous.guiapp.shell import AppShell
+
+
+def _command_select(value):
+    control = MagicMock()
+    control.value = value
+    control.disabled = False
+    control.disable.side_effect = (
+        lambda: setattr(control, 'disabled', True)
+    )
+    control.enable.side_effect = (
+        lambda: setattr(control, 'disabled', False)
+    )
+    return control
+
+
+@pytest.mark.parametrize(
+    ('solo', 'expected_mode'),
+    [
+        (False, 'crowdsourced'),
+        (True, 'solo'),
+    ],
+)
+def test_issue_331_journal_import_is_not_initial_database_setup(
+    monkeypatch,
+    solo,
+    expected_mode,
+):
+    store = GuiStore.default()
+    assert store.data_mode is None
+    monkeypatch.setattr(shell_module, 'get_gui_search_service', object)
+    shell = AppShell(store)
+    shell.command_select = _command_select(shell.session.selected_command)
+    shell._refresh_ui = MagicMock()
+    shell._show_import_summary = MagicMock()
+    saved_modes = []
+    monkeypatch.setattr(
+        shell_module,
+        'save_gui_store',
+        lambda current_store: saved_modes.append(current_store.data_mode),
+    )
+    monkeypatch.setattr(
+        shell_module,
+        'read_journal_facts',
+        lambda _journal_dir: JournalFacts(
+            commander_name='Acceptance Commander',
+            credits=12_345_678,
+            cargo_capacity=64,
+            insurance=765_432,
+            ship_name='Acceptance Ship',
+        ),
+    )
+    assert shell.session.selected_command == 'import'
+    assert store.selected_command == 'import'
+    shell._on_import_from_journal()
+    assert shell.session.global_state.commander_name == 'Acceptance Commander'
+    assert shell.session.global_state.credits == 12_345_678
+    assert store.global_settings.commander_name == 'Acceptance Commander'
+    assert store.global_settings.credits == 12_345_678
+    assert shell.session.ship_state.ship_name == 'Acceptance Ship'
+    assert shell.session.ship_state.capacity == 64
+    assert shell.session.ship_state.insurance == 765_432
+    assert shell.session.ship_state.is_dirty is True
+    assert store.data_mode is None
+    assert shell.session.execution.status is ExecutionStatus.IDLE
+    assert saved_modes == [None]
+    shell.command_select.value = 'run'
+    asyncio.run(shell._on_command_changed(SimpleNamespace(value='run')))
+    assert shell.session.selected_command == 'import'
+    assert store.selected_command == 'import'
+    assert shell.command_select.value == 'import'
+    assert saved_modes == [None]
+    if solo:
+        shell.session.draft.main_values['solo'] = True
+    executed_requests = []
+
+    async def complete_td_import(
+        *,
+        session,
+        request,
+        refresh_ui,
+        window_close_state,
+    ):
+        executed_requests.append(request)
+        session.set_execution(
+            status=ExecutionStatus.SUCCEEDED,
+            active_command='import',
+        )
+
+    monkeypatch.setattr(
+        shell_module,
+        'run_import_execution',
+        complete_td_import,
+    )
+    asyncio.run(shell._on_execute_command())
+    assert bool(executed_requests[0].main_values.get('solo')) is solo
+    assert store.data_mode == expected_mode
+    assert shell.command_select.disabled is False
+    assert saved_modes == [None, expected_mode]
+    shell.command_select.value = 'run'
+    asyncio.run(shell._on_command_changed(SimpleNamespace(value='run')))
+    assert shell.session.selected_command == 'run'
+    assert store.selected_command == 'run'
+    assert saved_modes == [None, expected_mode, expected_mode]

--- a/tests/test_gui_profiles.py
+++ b/tests/test_gui_profiles.py
@@ -1,4 +1,39 @@
-from tradedangerous.guiapp.profiles import CommandDraft, GuiStore, load_gui_store, make_profile_id, save_gui_store
+import json
+
+from tradedangerous.guiapp.profiles import (
+    CommandDraft,
+    GuiStore,
+    load_gui_store,
+    make_profile_id,
+    save_gui_store,
+)
+
+
+def test_guistore_default_data_mode_is_unset():
+    assert GuiStore.default().data_mode is None
+
+
+def test_existing_state_without_data_mode_loads_as_crowdsourced(tmp_path):
+    payload = GuiStore.default().to_dict()
+    payload.pop('data_mode')
+    path = tmp_path / 'gui-state.json'
+    path.write_text(json.dumps(payload), encoding='utf-8')
+
+    loaded = load_gui_store(path)
+
+    assert loaded.data_mode == 'crowdsourced'
+
+
+def test_explicit_data_modes_round_trip(tmp_path):
+    for data_mode in ('crowdsourced', 'solo'):
+        store = GuiStore.default()
+        store.data_mode = data_mode
+        path = tmp_path / f'{data_mode}-gui-state.json'
+
+        save_gui_store(store, path)
+        loaded = load_gui_store(path)
+
+        assert loaded.data_mode == data_mode
 
 def test_make_profile_id_slugifies_and_deduplicates():
     existing = {'cobra-mk-iii', 'cobra-mk-iii-2'}

--- a/tests/test_gui_run_missing_system.py
+++ b/tests/test_gui_run_missing_system.py
@@ -1,0 +1,212 @@
+from functools import partial
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+import tradedangerous.guiapp.run_view as run_view_module
+import tradedangerous.guiapp.shell as shell_module
+from tradedangerous.guiapp.gui_search import GuiSearchDatabaseError
+from tradedangerous.guiapp.profiles import (
+    CommandDraft,
+    GuiStore,
+    load_gui_store,
+    save_gui_store,
+)
+from tradedangerous.guiapp.run_view import RunWorkspace
+from tradedangerous.guiapp.shell import AppShell, _safe_resolve_system
+
+
+START_FIELD = {
+    'system_key': 'startSystem',
+    'station_key': 'startStation',
+    'combined_key': 'starting',
+    'selected_attr': 'selected_start_system_id',
+    'station_autocomplete_attr': 'start_station_autocomplete',
+    'missing_attr': 'missing_start_system_name',
+    'warning_label_attr': 'start_system_warning_label',
+}
+
+
+def _workspace(*, data_mode, draft, resolve_system, database_search_failed=None):
+    return RunWorkspace(
+        draft,
+        on_changed=MagicMock(),
+        on_execute=MagicMock(),
+        on_copy_from_profile=MagicMock(),
+        resolve_system=resolve_system,
+        data_mode=data_mode,
+        database_search_failed=database_search_failed,
+    )
+
+
+def _attach_warning_labels(workspace):
+    workspace.start_system_warning_label = MagicMock()
+    workspace.start_system_warning_label.text = ''
+    workspace.end_system_warning_label = MagicMock()
+    workspace.end_system_warning_label.text = ''
+
+
+@pytest.mark.parametrize(
+    ('data_mode', 'expected_text'),
+    [
+        ('crowdsourced', 'Run Import to update the crowdsourced data'),
+        ('solo', 'not present in your solo database'),
+    ],
+)
+def test_missing_from_system_guidance_matches_data_mode(
+    data_mode,
+    expected_text,
+):
+    draft = CommandDraft(main_values={'startSystem': 'Unknown Place'})
+    workspace = _workspace(
+        data_mode=data_mode,
+        draft=draft,
+        resolve_system=lambda _text: None,
+    )
+    _attach_warning_labels(workspace)
+    workspace._normalize_run_state()
+    assert workspace.selected_start_system_id is None
+    assert workspace.missing_start_system_name == 'Unknown Place'
+    assert expected_text in workspace.start_system_warning_label.text
+    assert 'Unknown Place' in workspace.start_system_warning_label.text
+    assert draft.main_values['startSystem'] == 'Unknown Place'
+    workspace.start_system_warning_label.set_visibility.assert_called_with(True)
+    if data_mode == 'solo':
+        assert 'EDMC + UpdateTD' in workspace.start_system_warning_label.text
+        assert 'crowdsourced' not in workspace.start_system_warning_label.text
+        assert 'Run Import' not in workspace.start_system_warning_label.text
+
+
+def test_changed_and_cleared_from_system_updates_warning():
+    draft = CommandDraft(main_values={'startSystem': 'First Missing'})
+    workspace = _workspace(
+        data_mode='crowdsourced',
+        draft=draft,
+        resolve_system=lambda _text: None,
+    )
+    _attach_warning_labels(workspace)
+    workspace._normalize_run_state()
+    workspace._set_run_system_text('Second Missing', **START_FIELD)
+    assert workspace.missing_start_system_name == 'Second Missing'
+    assert 'Second Missing' in workspace.start_system_warning_label.text
+    assert 'First Missing' not in workspace.start_system_warning_label.text
+    workspace._set_run_system_text('', **START_FIELD)
+    assert workspace.missing_start_system_name is None
+    assert workspace.selected_start_system_id is None
+    assert 'startSystem' not in draft.main_values
+    workspace.start_system_warning_label.set_visibility.assert_called_with(False)
+
+
+def test_successful_exact_resolution_clears_from_system_warning():
+    draft = CommandDraft(main_values={'startSystem': 'Missing'})
+    resolver = MagicMock(side_effect=[None, SimpleNamespace(system_id=42)])
+    workspace = _workspace(
+        data_mode='crowdsourced',
+        draft=draft,
+        resolve_system=resolver,
+    )
+    _attach_warning_labels(workspace)
+    workspace._normalize_run_state()
+    workspace._set_run_system_text('Lave', **START_FIELD)
+    assert workspace.selected_start_system_id == 42
+    assert workspace.missing_start_system_name is None
+    workspace.start_system_warning_label.set_visibility.assert_called_with(False)
+
+
+def test_from_and_to_missing_system_warnings_remain_independent():
+    draft = CommandDraft(main_values={
+        'startSystem': 'Missing Start',
+        'endSystem': 'Missing End',
+    })
+    workspace = _workspace(
+        data_mode='crowdsourced',
+        draft=draft,
+        resolve_system=lambda _text: None,
+    )
+    _attach_warning_labels(workspace)
+    workspace._normalize_run_state()
+    workspace._set_run_system_text('', **START_FIELD)
+    assert workspace.missing_start_system_name is None
+    assert workspace.missing_end_system_name == 'Missing End'
+    assert 'Missing End' in workspace.end_system_warning_label.text
+    workspace.end_system_warning_label.set_visibility.assert_called_with(True)
+
+
+def test_database_failure_preempts_missing_system_warning():
+    error = GuiSearchDatabaseError('search failed')
+    service = SimpleNamespace(
+        resolve_system=MagicMock(side_effect=error),
+    )
+    shell = AppShell.__new__(AppShell)
+    shell.store = GuiStore.default()
+    shell.store.data_mode = 'crowdsourced'
+    shell.search_service = service
+    shell.search_database_error = None
+    shell.search_database_error_label = MagicMock()
+    shell.search_database_error_label.text = ''
+    draft = CommandDraft(main_values={'startSystem': 'Lave'})
+    workspace = _workspace(
+        data_mode='crowdsourced',
+        draft=draft,
+        resolve_system=partial(_safe_resolve_system, shell),
+        database_search_failed=lambda: shell.search_database_error is not None,
+    )
+    _attach_warning_labels(workspace)
+    workspace._normalize_run_state()
+    assert shell.search_database_error is error
+    assert workspace.selected_start_system_id is None
+    assert workspace.missing_start_system_name is None
+    assert 'not present' not in workspace.start_system_warning_label.text
+    workspace.start_system_warning_label.set_visibility.assert_called_with(False)
+    shell.search_database_error_label.set_visibility.assert_called_once_with(True)
+
+
+def test_persisted_missing_run_system_renders_guidance_on_startup(
+    monkeypatch,
+    tmp_path,
+):
+    store = GuiStore.default()
+    store.data_mode = 'solo'
+    store.drafts['run'].main_values['startSystem'] = 'Unrecorded System'
+    state_path = tmp_path / 'tradegui_state.json'
+    save_gui_store(store, state_path)
+    loaded_store = load_gui_store(state_path)
+    service = SimpleNamespace(resolve_system=MagicMock(return_value=None))
+    monkeypatch.setattr(
+        shell_module,
+        'get_gui_search_service',
+        lambda: service,
+    )
+    shell = AppShell(loaded_store)
+    shell.search_database_error_label = MagicMock()
+    shell.search_database_error_label.text = ''
+    shell.workspace_host = MagicMock()
+    shell.workspace_host.__enter__.return_value = shell.workspace_host
+    rendered_labels = []
+
+    def build_missing_workspace(workspace):
+        workspace._normalize_run_state()
+        workspace._build_missing_system_warning(
+            missing_attr='missing_start_system_name',
+            warning_label_attr='start_system_warning_label',
+        )
+
+    def make_label(text):
+        label = MagicMock()
+        label.text = text
+        rendered_labels.append(label)
+        return label
+
+    monkeypatch.setattr(shell_module.RunWorkspace, 'build', build_missing_workspace)
+    monkeypatch.setattr(run_view_module.ui, 'label', make_label)
+    shell._render_workspace()
+    assert loaded_store.drafts['run'].main_values['startSystem'] == (
+        'Unrecorded System'
+    )
+    assert shell.search_database_error is None
+    assert len(rendered_labels) == 1
+    service.resolve_system.assert_called_once_with('Unrecorded System')
+    assert 'Unrecorded System' in rendered_labels[0].text
+    assert 'solo database' in rendered_labels[0].text
+    rendered_labels[0].set_visibility.assert_called_once_with(True)

--- a/tests/test_gui_run_missing_system.py
+++ b/tests/test_gui_run_missing_system.py
@@ -27,6 +27,16 @@ START_FIELD = {
     'warning_label_attr': 'start_system_warning_label',
 }
 
+END_FIELD = {
+    'system_key': 'endSystem',
+    'station_key': 'endStation',
+    'combined_key': 'ending',
+    'selected_attr': 'selected_end_system_id',
+    'station_autocomplete_attr': 'end_station_autocomplete',
+    'missing_attr': 'missing_end_system_name',
+    'warning_label_attr': 'end_system_warning_label',
+}
+
 
 def _workspace(*, data_mode, draft, resolve_system, database_search_failed=None):
     return RunWorkspace(
@@ -162,6 +172,47 @@ def test_database_failure_preempts_missing_system_warning():
     shell.search_database_error_label.set_visibility.assert_called_once_with(True)
 
 
+def test_database_failure_suppresses_without_forgetting_other_missing_system():
+    error = GuiSearchDatabaseError('search failed')
+    service = SimpleNamespace(resolve_system=MagicMock(side_effect=[
+        None,
+        error,
+        SimpleNamespace(system_id=42),
+    ]))
+    shell = AppShell.__new__(AppShell)
+    shell.store = GuiStore.default()
+    shell.store.data_mode = 'crowdsourced'
+    shell.search_service = service
+    shell.search_database_error = None
+    shell.search_database_error_label = MagicMock()
+    shell.search_database_error_label.text = ''
+    draft = CommandDraft(main_values={
+        'startSystem': 'Missing Start',
+        'endSystem': 'Uncheckable End',
+    })
+    workspace = _workspace(
+        data_mode='crowdsourced',
+        draft=draft,
+        resolve_system=partial(_safe_resolve_system, shell),
+        database_search_failed=lambda: shell.search_database_error is not None,
+    )
+    _attach_warning_labels(workspace)
+    shell.search_database_state_listener = (
+        workspace._refresh_missing_system_warnings
+    )
+    workspace._normalize_run_state()
+    assert shell.search_database_error is error
+    assert workspace.missing_start_system_name == 'Missing Start'
+    assert workspace.start_system_warning_label.text == ''
+    workspace.start_system_warning_label.set_visibility.assert_called_with(False)
+    workspace._set_run_system_text('Lave', **END_FIELD)
+    assert shell.search_database_error is None
+    assert workspace.selected_end_system_id == 42
+    assert workspace.missing_start_system_name == 'Missing Start'
+    assert 'Missing Start' in workspace.start_system_warning_label.text
+    workspace.start_system_warning_label.set_visibility.assert_called_with(True)
+
+
 def test_persisted_missing_run_system_renders_guidance_on_startup(
     monkeypatch,
     tmp_path,
@@ -184,8 +235,10 @@ def test_persisted_missing_run_system_renders_guidance_on_startup(
     shell.workspace_host = MagicMock()
     shell.workspace_host.__enter__.return_value = shell.workspace_host
     rendered_labels = []
+    rendered_workspaces = []
 
     def build_missing_workspace(workspace):
+        rendered_workspaces.append(workspace)
         workspace._normalize_run_state()
         workspace._build_missing_system_warning(
             missing_attr='missing_start_system_name',
@@ -206,6 +259,9 @@ def test_persisted_missing_run_system_renders_guidance_on_startup(
     )
     assert shell.search_database_error is None
     assert len(rendered_labels) == 1
+    assert shell.search_database_state_listener == (
+        rendered_workspaces[0]._refresh_missing_system_warnings
+    )
     service.resolve_system.assert_called_once_with('Unrecorded System')
     assert 'Unrecorded System' in rendered_labels[0].text
     assert 'solo database' in rendered_labels[0].text

--- a/tests/test_gui_search.py
+++ b/tests/test_gui_search.py
@@ -1,0 +1,57 @@
+import pytest
+from sqlalchemy.exc import OperationalError
+
+from tradedangerous.db.orm_models import System
+from tradedangerous.guiapp.gui_search import (
+    GuiSearchDatabaseError,
+    GuiSearchService,
+)
+
+
+def _make_search_service(tmp_path, request, database_name):
+    config_path = tmp_path / f'{database_name}.ini'
+    config_path.write_text(
+        '[database]\n'
+        'backend = sqlite\n'
+        '\n'
+        '[paths]\n'
+        f'data_dir = {tmp_path}\n'
+        f'tmp_dir = {tmp_path}\n'
+        '\n'
+        '[sqlite]\n'
+        f'sqlite_filename = {database_name}.db\n',
+        encoding='utf-8',
+    )
+    service = GuiSearchService(cfg_path=config_path)
+    request.addfinalizer(service.engine.dispose)
+    return service
+
+
+def test_valid_database_preserves_no_result_semantics(tmp_path, request):
+    service = _make_search_service(tmp_path, request, 'valid-empty')
+    System.__table__.create(service.engine)
+    assert service.resolve_system('Something Missing') is None
+    assert service.suggest_systems('Something Missing') == []
+
+
+@pytest.mark.parametrize(
+    'method_name',
+    [
+        'suggest_systems',
+        'resolve_system',
+        'suggest_items',
+        'suggest_buy_search',
+        'suggest_run_avoid',
+        'suggest_stations',
+    ],
+)
+def test_public_database_searches_translate_query_failures(
+    tmp_path,
+    request,
+    method_name,
+):
+    service = _make_search_service(tmp_path, request, method_name)
+    with pytest.raises(GuiSearchDatabaseError) as raised:
+        getattr(service, method_name)('Something Missing')
+    assert isinstance(raised.value.__cause__, OperationalError)
+    assert 'no such table' in str(raised.value.__cause__)

--- a/tests/test_gui_search_boundary.py
+++ b/tests/test_gui_search_boundary.py
@@ -1,0 +1,201 @@
+import asyncio
+from functools import partial
+from types import SimpleNamespace
+from unittest.mock import MagicMock, call
+
+import pytest
+
+import tradedangerous.guiapp.shell as shell_module
+from tradedangerous.guiapp.autocomplete import AutocompleteInput
+from tradedangerous.guiapp.gui_search import GuiSearchDatabaseError
+from tradedangerous.guiapp.profiles import (
+    GuiStore,
+    load_gui_store,
+    save_gui_store,
+)
+from tradedangerous.guiapp.shell import (
+    AppShell,
+    _safe_resolve_system,
+    _safe_suggest_buy_search,
+    _safe_suggest_items,
+    _safe_suggest_run_avoid,
+    _safe_suggest_stations,
+    _safe_suggest_systems,
+)
+
+
+SEARCH_METHOD_NAMES = (
+    'suggest_systems',
+    'resolve_system',
+    'suggest_items',
+    'suggest_buy_search',
+    'suggest_run_avoid',
+    'suggest_stations',
+)
+
+
+def _search_service():
+    return SimpleNamespace(**{
+        method_name: MagicMock()
+        for method_name in SEARCH_METHOD_NAMES
+    })
+
+
+def _shell(*, data_mode, search_service):
+    shell = AppShell.__new__(AppShell)
+    shell.store = GuiStore.default()
+    shell.store.data_mode = data_mode
+    shell.search_service = search_service
+    shell.search_database_error = None
+    shell.search_database_error_label = MagicMock()
+    shell.search_database_error_label.text = ''
+    return shell
+
+
+@pytest.mark.parametrize(
+    ('safe_callback', 'service_method', 'args', 'fallback'),
+    [
+        (_safe_resolve_system, 'resolve_system', ('Lave',), None),
+        (_safe_suggest_systems, 'suggest_systems', ('Lav',), []),
+        (_safe_suggest_items, 'suggest_items', ('Gold',), []),
+        (_safe_suggest_buy_search, 'suggest_buy_search', ('Gold',), []),
+        (_safe_suggest_run_avoid, 'suggest_run_avoid', ('Gold',), []),
+        (_safe_suggest_stations, 'suggest_stations', ('Lave Station', 7), []),
+    ],
+)
+def test_safe_search_callbacks_translate_database_failure(
+    safe_callback,
+    service_method,
+    args,
+    fallback,
+):
+    error = GuiSearchDatabaseError('search failed')
+    service = _search_service()
+    getattr(service, service_method).side_effect = error
+    shell = _shell(data_mode='crowdsourced', search_service=service)
+    assert safe_callback(shell, *args) == fallback
+    assert shell.search_database_error is error
+    assert 'search_database_error' not in shell.store.to_dict()
+
+
+def test_ordinary_no_result_does_not_create_database_failure():
+    service = _search_service()
+    service.resolve_system.return_value = None
+    service.suggest_systems.return_value = []
+    shell = _shell(data_mode='crowdsourced', search_service=service)
+    assert _safe_resolve_system(shell, 'Missing') is None
+    assert _safe_suggest_systems(shell, 'Missing') == []
+    assert shell.search_database_error is None
+    shell.search_database_error_label.set_visibility.assert_not_called()
+
+
+def test_repeated_search_failures_show_one_persistent_diagnostic():
+    error = GuiSearchDatabaseError('search failed')
+    service = _search_service()
+    service.suggest_systems.side_effect = error
+    shell = _shell(data_mode='crowdsourced', search_service=service)
+    autocomplete = AutocompleteInput(
+        label='System',
+        fetch_suggestions=partial(_safe_suggest_systems, shell),
+        on_text_changed=lambda _text: None,
+        debounce_seconds=0,
+    )
+    autocomplete.overlay = MagicMock()
+    for query in ('L', 'La'):
+        autocomplete._latest_query = query
+        asyncio.run(autocomplete._run_search(expected_query=query))
+    assert service.suggest_systems.call_count == 2
+    assert autocomplete.overlay.clear.call_count == 2
+    assert shell.search_database_error_label.set_visibility.call_args_list == [
+        call(True),
+    ]
+
+
+def test_successful_search_clears_transient_database_failure():
+    error = GuiSearchDatabaseError('search failed')
+    service = _search_service()
+    service.suggest_systems.side_effect = [error, []]
+    shell = _shell(data_mode='crowdsourced', search_service=service)
+    assert _safe_suggest_systems(shell, 'L') == []
+    assert _safe_suggest_systems(shell, 'La') == []
+    assert shell.search_database_error is None
+    assert shell.search_database_error_label.set_visibility.call_args_list == [
+        call(True),
+        call(False),
+    ]
+
+
+@pytest.mark.parametrize(
+    ('data_mode', 'expected_text'),
+    [
+        ('crowdsourced', 'initialise or rebuild the crowdsourced data'),
+        ('solo', 'use Solo to initialise or rebuild'),
+        (None, 'Complete the initial Import setup'),
+    ],
+)
+def test_database_failure_guidance_matches_data_mode(
+    data_mode,
+    expected_text,
+):
+    error = GuiSearchDatabaseError('search failed')
+    service = _search_service()
+    service.resolve_system.side_effect = error
+    shell = _shell(data_mode=data_mode, search_service=service)
+    assert _safe_resolve_system(shell, 'Lave') is None
+    assert expected_text in shell.search_database_error_label.text
+    if data_mode == 'solo':
+        assert 'EDMC + UpdateTD' in shell.search_database_error_label.text
+        assert 'crowdsourced' not in shell.search_database_error_label.text
+
+
+def test_safe_boundary_does_not_catch_unexpected_errors():
+    service = _search_service()
+    service.resolve_system.side_effect = RuntimeError('unexpected')
+    shell = _shell(data_mode='crowdsourced', search_service=service)
+    with pytest.raises(RuntimeError, match='unexpected'):
+        _safe_resolve_system(shell, 'Lave')
+    assert shell.search_database_error is None
+
+
+def test_persisted_run_system_survives_failed_startup_resolution(
+    monkeypatch,
+    tmp_path,
+):
+    store = GuiStore.default()
+    store.data_mode = 'crowdsourced'
+    store.drafts['run'].main_values['startSystem'] = 'Shinrarta Dezhra'
+    state_path = tmp_path / 'tradegui_state.json'
+    save_gui_store(store, state_path)
+    loaded_store = load_gui_store(state_path)
+    error = GuiSearchDatabaseError('search failed')
+    service = _search_service()
+    service.resolve_system.side_effect = error
+    monkeypatch.setattr(
+        shell_module,
+        'get_gui_search_service',
+        lambda: service,
+    )
+    shell = AppShell(loaded_store)
+    shell.search_database_error_label = MagicMock()
+    shell.search_database_error_label.text = ''
+    shell.workspace_host = MagicMock()
+    shell.workspace_host.__enter__.return_value = shell.workspace_host
+    built_workspaces = []
+    monkeypatch.setattr(
+        shell_module.RunWorkspace,
+        'build',
+        lambda workspace: (
+            built_workspaces.append(workspace),
+            workspace._normalize_run_state(),
+        ),
+    )
+    shell._render_workspace()
+    assert len(built_workspaces) == 1
+    assert built_workspaces[0].selected_start_system_id is None
+    assert loaded_store.drafts['run'].main_values['startSystem'] == (
+        'Shinrarta Dezhra'
+    )
+    assert shell.search_database_error is error
+    shell.search_database_error_label.set_visibility.assert_called_once_with(
+        True
+    )

--- a/tradedangerous/guiapp/gui_search.py
+++ b/tradedangerous/guiapp/gui_search.py
@@ -1,14 +1,31 @@
 from __future__ import annotations
 
+from collections.abc import Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Literal
 
 from sqlalchemy import func
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.orm import Session
 
 from tradedangerous.db import get_session_factory, make_engine_from_config
 from tradedangerous.db.orm_models import Category, Item, Ship, Station, System
 from tradedangerous.db.paths import resolve_db_config_path
+
+class GuiSearchDatabaseError(RuntimeError):
+    """Raised when a database-backed GUI lookup cannot be performed."""
+
+@contextmanager
+def _database_session(session_factory) -> Iterator[Session]:
+    try:
+        with session_factory() as session:
+            yield session
+    except SQLAlchemyError as exc:
+        raise GuiSearchDatabaseError(
+            'Database-backed GUI search failed.'
+        ) from exc
 
 @dataclass(frozen=True, slots=True)
 class Suggestion:
@@ -45,7 +62,7 @@ class GuiSearchService:
         if not query_text or bounded_limit <= 0:
             return []
         
-        with self._session_factory() as session:
+        with _database_session(self._session_factory) as session:
             suggestions: list[Suggestion] = []
             seen_system_ids: set[int] = set()
             
@@ -104,7 +121,7 @@ class GuiSearchService:
         if not query_text:
             return None
         
-        with self._session_factory() as session:
+        with _database_session(self._session_factory) as session:
             row = (
                 session.query(
                     System.system_id,
@@ -144,7 +161,7 @@ class GuiSearchService:
         if not query_text or bounded_limit <= 0:
             return []
         
-        with self._session_factory() as session:
+        with _database_session(self._session_factory) as session:
             suggestions: list[Suggestion] = []
             seen_item_ids: set[int] = set()
             base_query = (
@@ -209,7 +226,7 @@ class GuiSearchService:
         if not query_text or bounded_limit <= 0:
             return []
         
-        with self._session_factory() as session:
+        with _database_session(self._session_factory) as session:
             suggestions: list[Suggestion] = []
             seen_category_ids: set[int] = set()
             seen_item_ids: set[int] = set()
@@ -381,7 +398,7 @@ class GuiSearchService:
         if not query_text or bounded_limit <= 0:
             return []
         
-        with self._session_factory() as session:
+        with _database_session(self._session_factory) as session:
             suggestions: list[Suggestion] = []
             seen_system_ids: set[int] = set()
             seen_item_ids: set[int] = set()
@@ -497,7 +514,7 @@ class GuiSearchService:
         if not query_text or bounded_limit <= 0:
             return []
         
-        with self._session_factory() as session:
+        with _database_session(self._session_factory) as session:
             suggestions: list[Suggestion] = []
             seen_station_ids: set[int] = set()
             base_query = (

--- a/tradedangerous/guiapp/import_view.py
+++ b/tradedangerous/guiapp/import_view.py
@@ -80,43 +80,43 @@ class ImportWorkspace:
         with ui.column().classes('w-full gap-2').style(
             'padding: 0.25rem 0.5rem 0.5rem 0.25rem;'
         ):
-            if self.initial_setup:
-                with ui.card().classes('w-full gap-2'):
-                    ui.label('Choose your data workflow').classes('text-lg')
-                    ui.label(
-                        'Trade Dangerous needs an initial Import before its '
-                        'database-backed commands are available. Use the '
-                        'existing Solo option below to choose a workflow, '
-                        'then select Start Import.'
-                    ).classes('text-sm text-gray-700 whitespace-pre-wrap')
-                    ui.label('Crowdsourced').classes('text-weight-medium')
-                    ui.label(
-                        'Leave Solo unticked. The normal Trade Dangerous '
-                        'Import initialises and populates the database with '
-                        'the standard crowdsourced data.'
-                    ).classes('text-sm text-gray-700 whitespace-pre-wrap')
-                    ui.label('Solo').classes('text-weight-medium')
-                    ui.label(
-                        'Tick Solo if you maintain your own observed market '
-                        'data. Import creates the schema and base data without '
-                        'downloading crowdsourced market listings or '
-                        'ship-vendor data.'
-                    ).classes('text-sm text-gray-700 whitespace-pre-wrap')
-                    ui.label(
-                        'I maintain my own solo data with EDMC + UpdateTD '
-                        '(or another data source).'
-                    ).classes('text-sm text-gray-700 whitespace-pre-wrap')
-                    ui.link(
-                        'EDMC + UpdateTD',
-                        UPDATE_TD_URL,
-                        new_tab=True,
-                    ).classes('text-sm')
-                    ui.label(
-                        'EDMC + UpdateTD is the recommended and supported '
-                        'workflow for ongoing solo data collection. Another '
-                        'data source may be used, but is not specifically '
-                        'supported by Trade Dangerous.'
-                    ).classes('text-sm text-gray-700 whitespace-pre-wrap')
+            self.onboarding_card = ui.card().classes('w-full gap-2')
+            with self.onboarding_card:
+                ui.label('Choose your data workflow').classes('text-lg')
+                ui.label(
+                    'Trade Dangerous needs an initial Import before its '
+                    'database-backed commands are available. Use the '
+                    'existing Solo option below to choose a workflow, '
+                    'then select Start Import.'
+                ).classes('text-sm text-gray-700 whitespace-pre-wrap')
+                ui.label('Crowdsourced').classes('text-weight-medium')
+                ui.label(
+                    'Leave Solo unticked. The normal Trade Dangerous '
+                    'Import initialises and populates the database with '
+                    'the standard crowdsourced data.'
+                ).classes('text-sm text-gray-700 whitespace-pre-wrap')
+                ui.label('Solo').classes('text-weight-medium')
+                ui.label(
+                    'Tick Solo if you maintain your own observed market '
+                    'data. Import creates the schema and base data without '
+                    'downloading crowdsourced market listings or '
+                    'ship-vendor data.'
+                ).classes('text-sm text-gray-700 whitespace-pre-wrap')
+                ui.label(
+                    'I maintain my own solo data with EDMC + UpdateTD '
+                    '(or another data source).'
+                ).classes('text-sm text-gray-700 whitespace-pre-wrap')
+                ui.link(
+                    'EDMC + UpdateTD',
+                    UPDATE_TD_URL,
+                    new_tab=True,
+                ).classes('text-sm')
+                ui.label(
+                    'EDMC + UpdateTD is the recommended and supported '
+                    'workflow for ongoing solo data collection. Another '
+                    'data source may be used, but is not specifically '
+                    'supported by Trade Dangerous.'
+                ).classes('text-sm text-gray-700 whitespace-pre-wrap')
             with ui.row().classes('w-full gap-2 items-center'):
                 self.start_button = ui.button(
                     'Start Import',
@@ -176,6 +176,10 @@ class ImportWorkspace:
                     )
         
         self.refresh(self.execution)
+        self.refresh_onboarding(
+            initial_setup=self.initial_setup,
+            running=self.execution.status == ExecutionStatus.RUNNING,
+        )
     
     def _build_option_group(
         self,
@@ -291,6 +295,15 @@ class ImportWorkspace:
             execution.error_message or '',
         )
         self.log_label.text = self._log_text(execution)
+
+    def refresh_onboarding(
+        self,
+        *,
+        initial_setup: bool,
+        running: bool,
+    ) -> None:
+        self.initial_setup = initial_setup
+        self.onboarding_card.set_visibility(initial_setup and not running)
     
     @staticmethod
     def _set_optional_label(label: Any, text: str) -> None:

--- a/tradedangerous/guiapp/import_view.py
+++ b/tradedangerous/guiapp/import_view.py
@@ -5,6 +5,8 @@ from nicegui import ui
 from .profiles import CommandDraft
 from .session import ExecutionState, ExecutionStatus
 
+UPDATE_TD_URL = 'https://github.com/bgol/UpdateTD'
+
 IMPORT_HELP_ROWS: tuple[tuple[str, str], ...] = (
     ('All', 'Update everything with the latest dump files.'),
     ('Clean', 'Erase all data and rebuild it from scratch.'),
@@ -15,7 +17,9 @@ IMPORT_HELP_ROWS: tuple[tuple[str, str], ...] = (
     ),
     (
         'Solo',
-        "Don't download crowd-sourced market data. Skips vendor regeneration and overrides All and Clean.",
+        'Do not download crowdsourced market listings or ship-vendor data. '
+        'On first setup, this still creates the database schema and base data. '
+        'Solo overrides All and Clean.',
     ),
     ('Purge', 'Remove empty systems that previously had fleet carriers.'),
     (
@@ -36,6 +40,7 @@ class ImportWorkspace:
         draft: CommandDraft,
         execution: ExecutionState,
         *,
+        initial_setup: bool,
         on_changed: Callable[[], None],
         on_execute: Callable[[], None],
         on_arm_stop: Callable[[], None],
@@ -44,6 +49,7 @@ class ImportWorkspace:
     ) -> None:
         self.draft = draft
         self.execution = execution
+        self.initial_setup = initial_setup
         self.on_changed = on_changed
         self.on_execute = on_execute
         self.on_arm_stop = on_arm_stop
@@ -74,6 +80,43 @@ class ImportWorkspace:
         with ui.column().classes('w-full gap-2').style(
             'padding: 0.25rem 0.5rem 0.5rem 0.25rem;'
         ):
+            if self.initial_setup:
+                with ui.card().classes('w-full gap-2'):
+                    ui.label('Choose your data workflow').classes('text-lg')
+                    ui.label(
+                        'Trade Dangerous needs an initial Import before its '
+                        'database-backed commands are available. Use the '
+                        'existing Solo option below to choose a workflow, '
+                        'then select Start Import.'
+                    ).classes('text-sm text-gray-700 whitespace-pre-wrap')
+                    ui.label('Crowdsourced').classes('text-weight-medium')
+                    ui.label(
+                        'Leave Solo unticked. The normal Trade Dangerous '
+                        'Import initialises and populates the database with '
+                        'the standard crowdsourced data.'
+                    ).classes('text-sm text-gray-700 whitespace-pre-wrap')
+                    ui.label('Solo').classes('text-weight-medium')
+                    ui.label(
+                        'Tick Solo if you maintain your own observed market '
+                        'data. Import creates the schema and base data without '
+                        'downloading crowdsourced market listings or '
+                        'ship-vendor data.'
+                    ).classes('text-sm text-gray-700 whitespace-pre-wrap')
+                    ui.label(
+                        'I maintain my own solo data with EDMC + UpdateTD '
+                        '(or another data source).'
+                    ).classes('text-sm text-gray-700 whitespace-pre-wrap')
+                    ui.link(
+                        'EDMC + UpdateTD',
+                        UPDATE_TD_URL,
+                        new_tab=True,
+                    ).classes('text-sm')
+                    ui.label(
+                        'EDMC + UpdateTD is the recommended and supported '
+                        'workflow for ongoing solo data collection. Another '
+                        'data source may be used, but is not specifically '
+                        'supported by Trade Dangerous.'
+                    ).classes('text-sm text-gray-700 whitespace-pre-wrap')
             with ui.row().classes('w-full gap-2 items-center'):
                 self.start_button = ui.button(
                     'Start Import',

--- a/tradedangerous/guiapp/profiles.py
+++ b/tradedangerous/guiapp/profiles.py
@@ -7,7 +7,7 @@ import json
 import re
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import Any, Literal
 
 from tradedangerous.db.paths import resolve_data_dir, resolve_db_config_path
 
@@ -21,6 +21,7 @@ _IMPORT_TRANSIENT_FLAGS = frozenset({
     'optimize',
     'force',
 })
+DataMode = Literal['crowdsourced', 'solo']
 
 
 def _serialize_command_draft(command: str, draft: 'CommandDraft') -> dict[str, Any]:
@@ -44,6 +45,15 @@ def _coerce_launcher_port(value: Any) -> int | None:
     if port < LAUNCHER_PORT_MIN or port > LAUNCHER_PORT_MAX:
         return None
     return port
+
+
+def _load_data_mode(data: dict[str, Any]) -> DataMode | None:
+    if 'data_mode' not in data:
+        return 'crowdsourced'
+    value = data.get('data_mode')
+    if value is None or value in ('crowdsourced', 'solo'):
+        return value
+    return 'crowdsourced'
 
 @dataclass(slots=True)
 class GlobalSettings:
@@ -126,6 +136,7 @@ class GuiStore:
     """Persisted GUI state loaded from and saved to the JSON sidecar file."""
     
     schema_version: int = SCHEMA_VERSION
+    data_mode: DataMode | None = None
     launcher_port: int | None = None
     # Optional override for the Elite Dangerous journal directory. Blank/None
     # means "auto", preserving the CLI's normal env-var/OS-default discovery.
@@ -146,6 +157,7 @@ class GuiStore:
             ship_name='Ship 1',
         )
         return cls(
+            data_mode=None,
             selected_profile_id=default_profile.profile_id,
             selected_command='run',
             profiles=[default_profile],
@@ -157,6 +169,7 @@ class GuiStore:
     def from_dict(cls, data: dict[str, Any]) -> 'GuiStore':
         store = cls(
             schema_version=int(data.get('schema_version') or SCHEMA_VERSION),
+            data_mode=_load_data_mode(data),
             launcher_port=_coerce_launcher_port(data.get('launcher_port')),
             journal_dir=(data.get('journal_dir') or None),
             selected_profile_id=data.get('selected_profile_id'),
@@ -178,6 +191,7 @@ class GuiStore:
     def to_dict(self) -> dict[str, Any]:
         return {
             'schema_version': self.schema_version,
+            'data_mode': self.data_mode,
             'launcher_port': self.launcher_port,
             'journal_dir': self.journal_dir,
             'selected_profile_id': self.selected_profile_id,

--- a/tradedangerous/guiapp/run_view.py
+++ b/tradedangerous/guiapp/run_view.py
@@ -146,9 +146,21 @@ class RunWorkspace(DraftValueHelper):
         warning_label_attr: str,
     ) -> None:
         setattr(self, missing_attr, system_name)
+        self._refresh_missing_system_warning(
+            missing_attr=missing_attr,
+            warning_label_attr=warning_label_attr,
+        )
+
+    def _refresh_missing_system_warning(
+        self,
+        *,
+        missing_attr: str,
+        warning_label_attr: str,
+    ) -> None:
         label = getattr(self, warning_label_attr, None)
         if label is None:
             return
+        system_name = getattr(self, missing_attr)
         if system_name is None or self._database_search_is_unavailable():
             label.text = ''
             label.set_visibility(False)
@@ -160,14 +172,12 @@ class RunWorkspace(DraftValueHelper):
         label.text = message.format(system_name=system_name)
         label.set_visibility(True)
 
-    def _clear_missing_system_warnings(self) -> None:
-        self._update_missing_system_warning(
-            None,
+    def _refresh_missing_system_warnings(self) -> None:
+        self._refresh_missing_system_warning(
             missing_attr='missing_start_system_name',
             warning_label_attr='start_system_warning_label',
         )
-        self._update_missing_system_warning(
-            None,
+        self._refresh_missing_system_warning(
             missing_attr='missing_end_system_name',
             warning_label_attr='end_system_warning_label',
         )
@@ -181,8 +191,7 @@ class RunWorkspace(DraftValueHelper):
         warning_label = ui.label('')
         warning_label.classes('text-sm text-warning whitespace-pre-wrap')
         setattr(self, warning_label_attr, warning_label)
-        self._update_missing_system_warning(
-            getattr(self, missing_attr),
+        self._refresh_missing_system_warning(
             missing_attr=missing_attr,
             warning_label_attr=warning_label_attr,
         )
@@ -209,10 +218,17 @@ class RunWorkspace(DraftValueHelper):
                 warning_label_attr=warning_label_attr,
             )
             return None
+        known_missing_name = getattr(self, missing_attr)
+        if known_missing_name is not None and known_missing_name != cleaned:
+            self._update_missing_system_warning(
+                None,
+                missing_attr=missing_attr,
+                warning_label_attr=warning_label_attr,
+            )
         system_id = self._resolve_run_system_id(cleaned)
         if system_id is None:
             if self._database_search_is_unavailable():
-                self._clear_missing_system_warnings()
+                self._refresh_missing_system_warnings()
             else:
                 self._update_missing_system_warning(
                     cleaned,

--- a/tradedangerous/guiapp/run_view.py
+++ b/tradedangerous/guiapp/run_view.py
@@ -7,9 +7,26 @@ from typing import Any, Callable
 from nicegui import ui
 
 from .autocomplete import AutocompleteInput, build_system_autocomplete_input
-from .profiles import CommandDraft
+from .profiles import CommandDraft, DataMode
 from .shared_draft_helpers import DraftValueHelper
 from .shared_filter_view import build_shared_filter_section
+
+_MISSING_SYSTEM_MESSAGES: dict[DataMode | None, str] = {
+    'crowdsourced': (
+        'System "{system_name}" is not present in your Trade Dangerous '
+        'database. Run Import to update the crowdsourced data if the system '
+        'should be available.'
+    ),
+    'solo': (
+        'System "{system_name}" is not present in your solo database. Check '
+        'that your solo data source collected the system when you visited it. '
+        'EDMC + UpdateTD is the recommended and supported solo workflow.'
+    ),
+    None: (
+        'System "{system_name}" cannot be checked until the initial Import '
+        'setup is complete.'
+    ),
+}
 
 
 class RunWorkspace(DraftValueHelper):
@@ -26,6 +43,8 @@ class RunWorkspace(DraftValueHelper):
         suggest_stations: Callable[..., list[object]] | None = None,
         suggest_run_avoid: Callable[[str], list[object]] | None = None,
         resolve_system: Callable[[str], object | None] | None = None,
+        data_mode: DataMode | None = None,
+        database_search_failed: Callable[[], bool] | None = None,
     ) -> None:
         self.draft = draft
         self.on_changed = on_changed
@@ -35,8 +54,14 @@ class RunWorkspace(DraftValueHelper):
         self.suggest_stations = suggest_stations
         self.suggest_run_avoid = suggest_run_avoid
         self.resolve_system = resolve_system
+        self.data_mode = data_mode
+        self.database_search_failed = database_search_failed
         self.selected_start_system_id: int | None = None
         self.selected_end_system_id: int | None = None
+        self.missing_start_system_name: str | None = None
+        self.missing_end_system_name: str | None = None
+        self.start_system_warning_label = None
+        self.end_system_warning_label = None
         self.start_station_autocomplete = None
         self.end_station_autocomplete = None
         self.run_via_dialog = None
@@ -96,8 +121,71 @@ class RunWorkspace(DraftValueHelper):
             combined_key='ending',
             allow_bare_system=True,
         )
-        self.selected_start_system_id = self._resolve_run_system_id(start_system)
-        self.selected_end_system_id = self._resolve_run_system_id(end_system)
+        self.selected_start_system_id = self._resolve_route_system_id(
+            start_system,
+            missing_attr='missing_start_system_name',
+            warning_label_attr='start_system_warning_label',
+        )
+        self.selected_end_system_id = self._resolve_route_system_id(
+            end_system,
+            missing_attr='missing_end_system_name',
+            warning_label_attr='end_system_warning_label',
+        )
+
+    def _database_search_is_unavailable(self) -> bool:
+        return (
+            self.database_search_failed is not None
+            and self.database_search_failed()
+        )
+
+    def _update_missing_system_warning(
+        self,
+        system_name: str | None,
+        *,
+        missing_attr: str,
+        warning_label_attr: str,
+    ) -> None:
+        setattr(self, missing_attr, system_name)
+        label = getattr(self, warning_label_attr, None)
+        if label is None:
+            return
+        if system_name is None or self._database_search_is_unavailable():
+            label.text = ''
+            label.set_visibility(False)
+            return
+        message = _MISSING_SYSTEM_MESSAGES.get(
+            self.data_mode,
+            _MISSING_SYSTEM_MESSAGES[None],
+        )
+        label.text = message.format(system_name=system_name)
+        label.set_visibility(True)
+
+    def _clear_missing_system_warnings(self) -> None:
+        self._update_missing_system_warning(
+            None,
+            missing_attr='missing_start_system_name',
+            warning_label_attr='start_system_warning_label',
+        )
+        self._update_missing_system_warning(
+            None,
+            missing_attr='missing_end_system_name',
+            warning_label_attr='end_system_warning_label',
+        )
+
+    def _build_missing_system_warning(
+        self,
+        *,
+        missing_attr: str,
+        warning_label_attr: str,
+    ) -> None:
+        warning_label = ui.label('')
+        warning_label.classes('text-sm text-warning whitespace-pre-wrap')
+        setattr(self, warning_label_attr, warning_label)
+        self._update_missing_system_warning(
+            getattr(self, missing_attr),
+            missing_attr=missing_attr,
+            warning_label_attr=warning_label_attr,
+        )
 
     def _resolve_run_system_id(self, system_name: str | None) -> int | None:
         return self._resolve_suggestion_id(
@@ -105,6 +193,39 @@ class RunWorkspace(DraftValueHelper):
             resolver=self.resolve_system,
             id_attr='system_id',
         )
+
+    def _resolve_route_system_id(
+        self,
+        system_name: str | None,
+        *,
+        missing_attr: str,
+        warning_label_attr: str,
+    ) -> int | None:
+        cleaned = str(system_name or '').strip()
+        if cleaned == '' or self.resolve_system is None:
+            self._update_missing_system_warning(
+                None,
+                missing_attr=missing_attr,
+                warning_label_attr=warning_label_attr,
+            )
+            return None
+        system_id = self._resolve_run_system_id(cleaned)
+        if system_id is None:
+            if self._database_search_is_unavailable():
+                self._clear_missing_system_warnings()
+            else:
+                self._update_missing_system_warning(
+                    cleaned,
+                    missing_attr=missing_attr,
+                    warning_label_attr=warning_label_attr,
+                )
+            return None
+        self._update_missing_system_warning(
+            None,
+            missing_attr=missing_attr,
+            warning_label_attr=warning_label_attr,
+        )
+        return system_id
 
     def _run_system_value(
         self,
@@ -145,6 +266,8 @@ class RunWorkspace(DraftValueHelper):
         combined_key: str,
         selected_attr: str,
         station_autocomplete_attr: str,
+        missing_attr: str,
+        warning_label_attr: str,
     ) -> None:
         cleaned = str(value or '').strip()
         current = self._run_system_value(
@@ -157,6 +280,11 @@ class RunWorkspace(DraftValueHelper):
             self.draft.main_values.pop(station_key, None)
             self.draft.main_values.pop(combined_key, None)
             setattr(self, selected_attr, None)
+            self._update_missing_system_warning(
+                None,
+                missing_attr=missing_attr,
+                warning_label_attr=warning_label_attr,
+            )
             station_autocomplete = getattr(self, station_autocomplete_attr, None)
             if station_autocomplete is not None:
                 station_autocomplete.clear()
@@ -168,7 +296,15 @@ class RunWorkspace(DraftValueHelper):
             station_autocomplete = getattr(self, station_autocomplete_attr, None)
             if station_autocomplete is not None:
                 station_autocomplete.clear()
-        setattr(self, selected_attr, self._resolve_run_system_id(cleaned))
+        setattr(
+            self,
+            selected_attr,
+            self._resolve_route_system_id(
+                cleaned,
+                missing_attr=missing_attr,
+                warning_label_attr=warning_label_attr,
+            ),
+        )
         self._sync_station_pair_value(
             self.draft.main_values,
             system_key=system_key,
@@ -185,6 +321,24 @@ class RunWorkspace(DraftValueHelper):
         selected_attr: str,
     ) -> None:
         setattr(self, selected_attr, getattr(suggestion, 'system_id', None))
+
+    def _set_run_route_system_selected(
+        self,
+        suggestion: object,
+        *,
+        selected_attr: str,
+        missing_attr: str,
+        warning_label_attr: str,
+    ) -> None:
+        self._set_run_system_selected(
+            suggestion,
+            selected_attr=selected_attr,
+        )
+        self._update_missing_system_warning(
+            None,
+            missing_attr=missing_attr,
+            warning_label_attr=warning_label_attr,
+        )
 
     def _set_run_station_text(
         self,
@@ -351,6 +505,8 @@ class RunWorkspace(DraftValueHelper):
         combined_key: str,
         selected_attr: str,
         station_autocomplete_attr: str,
+        missing_attr: str,
+        warning_label_attr: str,
         system_tooltip: str,
         station_tooltip: str,
     ) -> None:
@@ -365,39 +521,52 @@ class RunWorkspace(DraftValueHelper):
             combined_key=combined_key,
         )
 
-        if self.suggest_systems is None:
-            ui.input(
-                system_label,
-                value=system_value,
-                on_change=lambda event: self._set_run_system_text(
-                    event.value,
-                    system_key=system_key,
-                    station_key=station_key,
-                    combined_key=combined_key,
-                    selected_attr=selected_attr,
-                    station_autocomplete_attr=station_autocomplete_attr,
-                ),
-            ).classes('min-w-0 w-full').tooltip(system_tooltip)
-        else:
-            AutocompleteInput(
-                label=system_label,
-                value=system_value,
-                fetch_suggestions=self.suggest_systems,
-                on_text_changed=lambda value: self._set_run_system_text(
-                    value,
-                    system_key=system_key,
-                    station_key=station_key,
-                    combined_key=combined_key,
-                    selected_attr=selected_attr,
-                    station_autocomplete_attr=station_autocomplete_attr,
-                ),
-                on_selected=lambda suggestion: self._set_run_system_selected(
-                    suggestion,
-                    selected_attr=selected_attr,
-                ),
-                tooltip=system_tooltip,
-                input_classes='min-w-0 w-full',
-            ).build()
+        with ui.column().classes('min-w-0 w-full gap-1'):
+            if self.suggest_systems is None:
+                ui.input(
+                    system_label,
+                    value=system_value,
+                    on_change=lambda event: self._set_run_system_text(
+                        event.value,
+                        system_key=system_key,
+                        station_key=station_key,
+                        combined_key=combined_key,
+                        selected_attr=selected_attr,
+                        station_autocomplete_attr=station_autocomplete_attr,
+                        missing_attr=missing_attr,
+                        warning_label_attr=warning_label_attr,
+                    ),
+                ).classes('w-full').tooltip(system_tooltip)
+            else:
+                AutocompleteInput(
+                    label=system_label,
+                    value=system_value,
+                    fetch_suggestions=self.suggest_systems,
+                    on_text_changed=lambda value: self._set_run_system_text(
+                        value,
+                        system_key=system_key,
+                        station_key=station_key,
+                        combined_key=combined_key,
+                        selected_attr=selected_attr,
+                        station_autocomplete_attr=station_autocomplete_attr,
+                        missing_attr=missing_attr,
+                        warning_label_attr=warning_label_attr,
+                    ),
+                    on_selected=lambda suggestion: (
+                        self._set_run_route_system_selected(
+                            suggestion,
+                            selected_attr=selected_attr,
+                            missing_attr=missing_attr,
+                            warning_label_attr=warning_label_attr,
+                        )
+                    ),
+                    tooltip=system_tooltip,
+                    input_classes='w-full',
+                ).build()
+            self._build_missing_system_warning(
+                missing_attr=missing_attr,
+                warning_label_attr=warning_label_attr,
+            )
 
         if self.suggest_stations is None:
             ui.input(
@@ -451,6 +620,8 @@ class RunWorkspace(DraftValueHelper):
                     combined_key='starting',
                     selected_attr='selected_start_system_id',
                     station_autocomplete_attr='start_station_autocomplete',
+                    missing_attr='missing_start_system_name',
+                    warning_label_attr='start_system_warning_label',
                     system_tooltip='System containing your starting station.',
                     station_tooltip='Station you are starting from.',
                 )
@@ -465,6 +636,8 @@ class RunWorkspace(DraftValueHelper):
                     combined_key='ending',
                     selected_attr='selected_end_system_id',
                     station_autocomplete_attr='end_station_autocomplete',
+                    missing_attr='missing_end_system_name',
+                    warning_label_attr='end_system_warning_label',
                     system_tooltip='System containing your destination station.',
                     station_tooltip='Station you are heading to.',
                 )

--- a/tradedangerous/guiapp/shell.py
+++ b/tradedangerous/guiapp/shell.py
@@ -790,6 +790,7 @@ class AppShell:
                 refresh_ui=self._refresh_ui_if_alive,
                 window_close_state=self.window_close_state,
             )
+            self._persist_initial_import_data_mode(request)
             return
         
         if self._has_pending_command_process():
@@ -883,6 +884,20 @@ class AppShell:
         self.active_command_task = asyncio.create_task(
             self._monitor_command_process(request=request, runner=runner)
         )
+
+    def _persist_initial_import_data_mode(
+        self,
+        request: GuiCommandRequest,
+    ) -> None:
+        if self.store.data_mode is not None:
+            return
+        if self.session.execution.status is not ExecutionStatus.SUCCEEDED:
+            return
+
+        self.store.data_mode = (
+            'solo' if request.main_values.get('solo') else 'crowdsourced'
+        )
+        save_gui_store(self.store)
     
     # The shell polls one child process from asyncio rather than awaiting a
     # thread-pool future. That keeps the UI responsive while still letting us

--- a/tradedangerous/guiapp/shell.py
+++ b/tradedangerous/guiapp/shell.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import asyncio
 import json
+from collections.abc import Callable
+from functools import partial
 from pathlib import Path
 from typing import Any
 
@@ -37,7 +39,7 @@ from . import native_bridge
 from .results_view import render_command_results
 from .session import ExecutionStatus, SessionState
 from .td_exec import GuiCommandRequest, TdCommandProcess, TdExecutor
-from .gui_search import get_gui_search_service
+from .gui_search import GuiSearchDatabaseError, get_gui_search_service
 from tradedangerous import TradeException
 
 COMMAND_OPTIONS: dict[str, str] = {
@@ -52,6 +54,126 @@ COMMAND_OPTIONS: dict[str, str] = {
     'import': 'Import',
     'settings': 'Settings',
 }
+
+_SEARCH_DATABASE_ERROR_MESSAGES: dict[str | None, str] = {
+    'crowdsourced': (
+        'Trade Dangerous cannot currently use its database. Open Import to '
+        'initialise or rebuild the crowdsourced data before using '
+        'database-backed commands.'
+    ),
+    'solo': (
+        'Trade Dangerous cannot currently use the solo database. Open Import '
+        'and use Solo to initialise or rebuild the required database '
+        'structure, then check your solo data source if necessary. EDMC + '
+        'UpdateTD is the recommended and supported solo workflow.'
+    ),
+    None: (
+        'Trade Dangerous cannot currently use its database. Complete the '
+        'initial Import setup before using database-backed commands.'
+    ),
+}
+
+def _safe_gui_search(
+    shell: 'AppShell',
+    search: Callable[..., Any],
+    fallback: Any,
+    *args: Any,
+    **kwargs: Any,
+) -> Any:
+    try:
+        result = search(*args, **kwargs)
+    except GuiSearchDatabaseError as exc:
+        if shell.search_database_error is None:
+            shell.search_database_error = exc
+            label = getattr(shell, 'search_database_error_label', None)
+            if label is not None:
+                label.text = _SEARCH_DATABASE_ERROR_MESSAGES.get(
+                    shell.store.data_mode,
+                    _SEARCH_DATABASE_ERROR_MESSAGES[None],
+                )
+                label.set_visibility(True)
+        return fallback
+    if shell.search_database_error is not None:
+        shell.search_database_error = None
+        label = getattr(shell, 'search_database_error_label', None)
+        if label is not None:
+            label.set_visibility(False)
+    return result
+
+def _safe_suggest_systems(
+    shell: 'AppShell',
+    text: str,
+    limit: int = 10,
+) -> list[Any]:
+    return _safe_gui_search(
+        shell,
+        shell.search_service.suggest_systems,
+        [],
+        text,
+        limit=limit,
+    )
+
+def _safe_resolve_system(shell: 'AppShell', text: str) -> Any | None:
+    return _safe_gui_search(
+        shell,
+        shell.search_service.resolve_system,
+        None,
+        text,
+    )
+
+def _safe_suggest_items(
+    shell: 'AppShell',
+    text: str,
+    limit: int = 10,
+) -> list[Any]:
+    return _safe_gui_search(
+        shell,
+        shell.search_service.suggest_items,
+        [],
+        text,
+        limit=limit,
+    )
+
+def _safe_suggest_buy_search(
+    shell: 'AppShell',
+    text: str,
+    limit: int = 10,
+) -> list[Any]:
+    return _safe_gui_search(
+        shell,
+        shell.search_service.suggest_buy_search,
+        [],
+        text,
+        limit=limit,
+    )
+
+def _safe_suggest_run_avoid(
+    shell: 'AppShell',
+    text: str,
+    limit: int = 10,
+) -> list[Any]:
+    return _safe_gui_search(
+        shell,
+        shell.search_service.suggest_run_avoid,
+        [],
+        text,
+        limit=limit,
+    )
+
+def _safe_suggest_stations(
+    shell: 'AppShell',
+    text: str,
+    system_id: int | None = None,
+    limit: int = 10,
+) -> list[Any]:
+    return _safe_gui_search(
+        shell,
+        shell.search_service.suggest_stations,
+        [],
+        text,
+        limit=limit,
+        system_id=system_id,
+    )
 
 class AppShell:
     """Own the long-lived widgets and coordinate session/store updates."""
@@ -70,6 +192,7 @@ class AppShell:
             self.session.set_command(self.store, 'import')
         self.executor = TdExecutor()
         self.search_service = get_gui_search_service()
+        self.search_database_error: GuiSearchDatabaseError | None = None
         self.active_command_process: TdCommandProcess | None = None
         self.active_command_task: asyncio.Task | None = None
         
@@ -94,6 +217,7 @@ class AppShell:
         self.body_query = None
         self.command_switch_dialog = None
         self.command_switch_message = None
+        self.search_database_error_label = None
         # GUI-native Run checklist stepper; its persistent dialog is built once
         # in build() so a results-pane refresh never destroys it.
         self.run_checklist = RunChecklist()
@@ -121,6 +245,12 @@ class AppShell:
         )
         with self.root_container:
             self._build_top_bar()
+            self.search_database_error_label = ui.label('').classes(
+                'w-full p-3 text-sm text-warning whitespace-pre-wrap'
+            ).style(
+                'border: 1px solid #f07b05; border-radius: 0.5rem;'
+            )
+            self.search_database_error_label.set_visibility(False)
             with ui.splitter(value=27).classes(
                 'w-full min-h-0 flex-1 overflow-hidden'
             ) as splitter:
@@ -1060,20 +1190,10 @@ class AppShell:
                     on_changed=self._on_run_draft_changed,
                     on_execute=self._on_execute_command,
                     on_copy_from_profile=self._on_copy_from_profile,
-                    suggest_systems=lambda text: self.search_service.suggest_systems(
-                        text,
-                        limit=10,
-                    ),
-                    suggest_stations=lambda text, system_id=None: self.search_service.suggest_stations(
-                        text,
-                        limit=10,
-                        system_id=system_id,
-                    ),
-                    suggest_run_avoid=lambda text: self.search_service.suggest_run_avoid(
-                        text,
-                        limit=10,
-                    ),
-                    resolve_system=self.search_service.resolve_system,
+                    suggest_systems=partial(_safe_suggest_systems, self),
+                    suggest_stations=partial(_safe_suggest_stations, self),
+                    suggest_run_avoid=partial(_safe_suggest_run_avoid, self),
+                    resolve_system=partial(_safe_resolve_system, self),
                 )
                 workspace.build()
             elif self.session.selected_command in {'buy', 'sell'}:
@@ -1082,17 +1202,11 @@ class AppShell:
                     self.session.draft,
                     on_changed=self._on_run_draft_changed,
                     on_execute=self._on_execute_command,
-                    suggest_systems=lambda text: self.search_service.suggest_systems(
-                        text,
-                        limit=10,
-                    ),
-                    suggest_items=lambda text: self.search_service.suggest_items(
-                        text,
-                        limit=10,
-                    ),
-                    suggest_buy_search=lambda text: self.search_service.suggest_buy_search(
-                        text,
-                        limit=10,
+                    suggest_systems=partial(_safe_suggest_systems, self),
+                    suggest_items=partial(_safe_suggest_items, self),
+                    suggest_buy_search=partial(
+                        _safe_suggest_buy_search,
+                        self,
                     ),
                 )
                 workspace.build()
@@ -1101,16 +1215,9 @@ class AppShell:
                     self.session.draft,
                     on_changed=self._on_run_draft_changed,
                     on_execute=self._on_execute_command,
-                    suggest_systems=lambda text: self.search_service.suggest_systems(
-                        text,
-                        limit=10,
-                    ),
-                    suggest_stations=lambda text, system_id=None: self.search_service.suggest_stations(
-                        text,
-                        limit=10,
-                        system_id=system_id,
-                    ),
-                    resolve_system=self.search_service.resolve_system,
+                    suggest_systems=partial(_safe_suggest_systems, self),
+                    suggest_stations=partial(_safe_suggest_stations, self),
+                    resolve_system=partial(_safe_resolve_system, self),
                 )
                 workspace.build()
             elif self.session.selected_command == 'local':
@@ -1118,10 +1225,7 @@ class AppShell:
                     self.session.draft,
                     on_changed=self._on_run_draft_changed,
                     on_execute=self._on_execute_command,
-                    suggest_systems=lambda text: self.search_service.suggest_systems(
-                        text,
-                        limit=10,
-                    ),
+                    suggest_systems=partial(_safe_suggest_systems, self),
                 )
                 workspace.build()
             elif self.session.selected_command == 'market':
@@ -1129,22 +1233,17 @@ class AppShell:
                     self.session.draft,
                     on_changed=self._on_run_draft_changed,
                     on_execute=self._on_execute_command,
-                    suggest_systems=lambda text: self.search_service.suggest_systems(
-                        text,
-                        limit=10,
-                    ),
+                    suggest_systems=partial(_safe_suggest_systems, self),
                     suggest_stations=lambda text, system_id=None: (
                         []
                         if system_id is None
-                        else self.search_service.suggest_stations(
+                        else _safe_suggest_stations(
+                            self,
                             text,
-                            limit=10,
                             system_id=system_id,
                         )
                     ),
-                    resolve_system=lambda text: self.search_service.resolve_system(
-                        text,
-                    ),
+                    resolve_system=partial(_safe_resolve_system, self),
                 )
                 workspace.build()
             elif self.session.selected_command == 'nav':
@@ -1152,10 +1251,7 @@ class AppShell:
                     self.session.draft,
                     on_changed=self._on_run_draft_changed,
                     on_execute=self._on_execute_command,
-                    suggest_systems=lambda text: self.search_service.suggest_systems(
-                        text,
-                        limit=10,
-                    ),
+                    suggest_systems=partial(_safe_suggest_systems, self),
                 )
                 workspace.build()
             elif self.session.selected_command == 'olddata':
@@ -1163,10 +1259,7 @@ class AppShell:
                     self.session.draft,
                     on_changed=self._on_run_draft_changed,
                     on_execute=self._on_execute_command,
-                    suggest_systems=lambda text: self.search_service.suggest_systems(
-                        text,
-                        limit=10,
-                    ),
+                    suggest_systems=partial(_safe_suggest_systems, self),
                 )
                 workspace.build()
             elif self.session.selected_command == 'settings':

--- a/tradedangerous/guiapp/shell.py
+++ b/tradedangerous/guiapp/shell.py
@@ -1194,6 +1194,10 @@ class AppShell:
                     suggest_stations=partial(_safe_suggest_stations, self),
                     suggest_run_avoid=partial(_safe_suggest_run_avoid, self),
                     resolve_system=partial(_safe_resolve_system, self),
+                    data_mode=self.store.data_mode,
+                    database_search_failed=lambda: (
+                        self.search_database_error is not None
+                    ),
                 )
                 workspace.build()
             elif self.session.selected_command in {'buy', 'sell'}:

--- a/tradedangerous/guiapp/shell.py
+++ b/tradedangerous/guiapp/shell.py
@@ -73,6 +73,12 @@ _SEARCH_DATABASE_ERROR_MESSAGES: dict[str | None, str] = {
     ),
 }
 
+
+def _notify_search_database_state_changed(shell: 'AppShell') -> None:
+    listener = getattr(shell, 'search_database_state_listener', None)
+    if listener is not None:
+        listener()
+
 def _safe_gui_search(
     shell: 'AppShell',
     search: Callable[..., Any],
@@ -92,12 +98,14 @@ def _safe_gui_search(
                     _SEARCH_DATABASE_ERROR_MESSAGES[None],
                 )
                 label.set_visibility(True)
+            _notify_search_database_state_changed(shell)
         return fallback
     if shell.search_database_error is not None:
         shell.search_database_error = None
         label = getattr(shell, 'search_database_error_label', None)
         if label is not None:
             label.set_visibility(False)
+        _notify_search_database_state_changed(shell)
     return result
 
 def _safe_suggest_systems(
@@ -193,6 +201,7 @@ class AppShell:
         self.executor = TdExecutor()
         self.search_service = get_gui_search_service()
         self.search_database_error: GuiSearchDatabaseError | None = None
+        self.search_database_state_listener: Callable[[], None] | None = None
         self.active_command_process: TdCommandProcess | None = None
         self.active_command_task: asyncio.Task | None = None
         
@@ -1182,6 +1191,7 @@ class AppShell:
     def _render_workspace(self) -> None:
         # Import keeps long-lived progress widgets and is rendered separately in
         # `_render_right_pane`; every other workspace can be rebuilt cheaply.
+        self.search_database_state_listener = None
         self.workspace_host.clear()
         with self.workspace_host:
             if self.session.selected_command == 'run':
@@ -1198,6 +1208,9 @@ class AppShell:
                     database_search_failed=lambda: (
                         self.search_database_error is not None
                     ),
+                )
+                self.search_database_state_listener = (
+                    workspace._refresh_missing_system_warnings
                 )
                 workspace.build()
             elif self.session.selected_command in {'buy', 'sell'}:

--- a/tradedangerous/guiapp/shell.py
+++ b/tradedangerous/guiapp/shell.py
@@ -66,6 +66,8 @@ class AppShell:
         self.store = store
         self.window_close_state = window_close_state
         self.session = SessionState.from_store(store)
+        if self.store.data_mode is None:
+            self.session.set_command(self.store, 'import')
         self.executor = TdExecutor()
         self.search_service = get_gui_search_service()
         self.active_command_process: TdCommandProcess | None = None
@@ -429,6 +431,9 @@ class AppShell:
         new_command = str(value)
         if new_command == self.session.selected_command:
             return
+        if self.store.data_mode is None and new_command != 'import':
+            self._restore_command_selection()
+            return
         
         if is_import_running(session=self.session):
             confirmed = await self._confirm_stop_before_switch(
@@ -791,6 +796,12 @@ class AppShell:
                 window_close_state=self.window_close_state,
             )
             self._persist_initial_import_data_mode(request)
+            command_select = getattr(self, 'command_select', None)
+            if command_select is not None:
+                if self.store.data_mode is None:
+                    command_select.disable()
+                else:
+                    command_select.enable()
             return
         
         if self._has_pending_command_process():
@@ -1194,6 +1205,7 @@ class AppShell:
                     workspace = ImportWorkspace(
                         self.session.draft,
                         self.session.execution,
+                        initial_setup=self.store.data_mode is None,
                         on_changed=self._on_run_draft_changed,
                         on_execute=self._on_execute_command,
                         on_arm_stop=self._on_begin_import_stop_confirmation,
@@ -1387,6 +1399,10 @@ class AppShell:
         self._refreshing_ui = True
         try:
             self.command_select.value = self.session.selected_command
+            if self.store.data_mode is None:
+                self.command_select.disable()
+            else:
+                self.command_select.enable()
             self.profile_select.set_options(self._profile_options())
             self.profile_select.value = self.session.selected_profile_id
             

--- a/tradedangerous/guiapp/shell.py
+++ b/tradedangerous/guiapp/shell.py
@@ -928,19 +928,25 @@ class AppShell:
             if consume_one_shot_import_flags(draft=self.session.draft):
                 save_gui_store(self.store)
                 self._refresh_ui()
-            await run_import_execution(
-                session=self.session,
-                request=request,
-                refresh_ui=self._refresh_ui_if_alive,
-                window_close_state=self.window_close_state,
-            )
-            self._persist_initial_import_data_mode(request)
-            command_select = getattr(self, 'command_select', None)
-            if command_select is not None:
-                if self.store.data_mode is None:
-                    command_select.disable()
-                else:
-                    command_select.enable()
+            self._refresh_import_onboarding(running=True)
+            try:
+                await run_import_execution(
+                    session=self.session,
+                    request=request,
+                    refresh_ui=self._refresh_ui_if_alive,
+                    window_close_state=self.window_close_state,
+                )
+                self._persist_initial_import_data_mode(request)
+                command_select = getattr(self, 'command_select', None)
+                if command_select is not None:
+                    if self.store.data_mode is None:
+                        command_select.disable()
+                    else:
+                        command_select.enable()
+            finally:
+                self._refresh_import_onboarding(
+                    running=is_import_running(session=self.session),
+                )
             return
         
         if self._has_pending_command_process():
@@ -1048,6 +1054,15 @@ class AppShell:
             'solo' if request.main_values.get('solo') else 'crowdsourced'
         )
         save_gui_store(self.store)
+
+    def _refresh_import_onboarding(self, *, running: bool) -> None:
+        workspace = getattr(self, 'import_workspace', None)
+        if workspace is None:
+            return
+        workspace.refresh_onboarding(
+            initial_setup=self.store.data_mode is None,
+            running=running,
+        )
     
     # The shell polls one child process from asyncio rather than awaiting a
     # thread-pool future. That keeps the UI responsive while still letting us


### PR DESCRIPTION
## Summary

Fixes #331: the GUI could crash, blank the workspace, or fail to start if database-backed system lookup was attempted before the Trade Dangerous database had been initialised.

The original failure was triggered by importing commander/ship details from the journal, entering a system in `run`, and saving before ever running the normal TD Import. A persisted unresolved system could then reproduce the failure on subsequent GUI startup.

## What changed

- Added explicit first-run database setup handling.
- Added persistent data workflow state for:
  - Crowdsourced
  - Solo
- Journal import no longer counts as database initialisation.
- Initial setup is only considered complete after a successful TD Import.
- Existing GUI state files without the new mode field remain compatible.
- Database/schema lookup failures are now contained at the GUI boundary rather than escaping through NiceGUI callbacks or page rendering.
- Missing systems in an otherwise valid database are handled separately from an unusable database.
- `run` now shows a concise:
  - `System "<name>" not found.`
  - with mode-aware Help explaining what to do next.
- Missing From/To systems remain independent.
- Database failure takes precedence over ordinary missing-system warnings.
- Solo setup/help text now makes clear that initial Solo Import creates the schema and imports core system, station and reference data, without downloading crowdsourced market listings or ship-vendor data.

## Validation

Tested against the original failure scenario on native Windows, including:

- fresh first-run startup;
- journal import before TD Import;
- successful Crowdsourced initial Import;
- successful Solo initial Import;
- stopped/failed first-run Import remaining incomplete;
- missing systems in a valid database;
- persisted unresolved systems across restart;
- startup with the database missing/unusable;
- recovery after restoring the database;
- legacy GUI state without the new `data_mode` field.

Automated regression coverage was added/updated for the #331 paths, including GUI search failure containment, first-run setup, mode persistence, missing-system behaviour, and persisted startup state.